### PR TITLE
Add .gitignore file enforcing line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Taken from accessibility-insights-web's config