### PR TITLE
remove axe typings that were only required by axe-utils

### DIFF
--- a/src/axe-extension.ts
+++ b/src/axe-extension.ts
@@ -1,36 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CheckConfiguration, RuleConfiguration } from './ruleresults';
-
 declare module 'axe-core/axe' {
-    const commons: {
-        aria: {
-            label: Function;
-            implicitRole: Function;
-            getRolesByType: Function;
-            lookupTable: any;
-        };
-        dom: {
-            isVisible: Function;
-            idrefs: (node: HTMLElement, attr: string) => HTMLElement[];
-        };
-        text: {
-            accessibleText: Function;
-        };
-    };
-
-    const utils: {
-        toArray: Function;
-        matchesSelector: Function;
-    };
-
-    const _audit: {
-        defaultConfig: {
-            rules: RuleConfiguration[];
-            checks: CheckConfiguration[];
-        };
-    };
-
     export interface AxeRawResult {
         id: string;
         result: string;


### PR DESCRIPTION
#### Description of changes

Removes the axe extensions that were only there for `axe-utils` benefit now that `axe-utils` is removed.

#### Pull request checklist

- [x] Addresses an existing issue: continues working on user story 1492620
- [x] **n/a** Added relevant unit test for your changes. (`npm run test`)
- [x] **n/a** Verified code coverage for the changes made.
