### PR TITLE
Export SarifLog from index.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "axe-sarif-converter",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "axe-sarif-converter",
-    "version": "0.0.1",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "axe-sarif-converter",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Convert axe-core accessibility scan results to the SARIF format",
     "main": "dist/index.js",
     "types": "dist/index.d.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { SarifConverter } from './sarif-converter';
 import { SarifLog } from './sarif/sarif-log';
 import { rulesWCAGConfiguration } from './wcag-mappings';
 
+export { SarifLog } from './sarif/sarif-log';
+
 export function convertAxeToSarif(axeResults: Axe.AxeResults): SarifLog {
     const resultDecorator = new ResultDecorator(rulesWCAGConfiguration);
     const decoratedAxeResults = resultDecorator.decorateResults(axeResults);


### PR DESCRIPTION
#### Description of changes

Type `SarifLog` is not exported from index.ts, meaning code example in README.md won't build.

```
error TS2305: Module '"node_modules/axe-sarif-converter/dist/index"' has no
exported member 'SarifLog'.

import { convertAxeToSarif, SarifLog } from 'axe-sarif-converter';
```

To make it build, `SarifLog` needs to be exported from package level (index.ts).

(Also fixed version in package-lock.json)

#### Pull request checklist

- [x] Added relevant unit test for your changes. (`npm run test`)
