### PR TITLE
remove audit warning by running npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -591,14 +591,6 @@
             "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
-            },
-            "dependencies": {
-                "sprintf-js": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                    "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-                    "dev": true
-                }
             }
         },
         "arr-diff": {
@@ -663,6 +655,15 @@
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
             "dev": true
+        },
+        "async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+            "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.11"
+            }
         },
         "async-limiter": {
             "version": "1.0.0",
@@ -1785,15 +1786,15 @@
             }
         },
         "glob": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-            "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^3.0.2",
+                "minimatch": "^3.0.4",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             }
@@ -1817,9 +1818,9 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-            "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+            "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
             "dev": true,
             "requires": {
                 "neo-async": "^2.6.0",
@@ -2216,34 +2217,110 @@
             "dev": true
         },
         "istanbul-api": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
-            "integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.4.tgz",
+            "integrity": "sha512-aAFQL0HA2BLUl18XmTQ7H7CGKI58DtZFvvfmg6e+rA3iNFergvpi16czLV4CpI7HOImMeZ5mqI62dvSNVtUQVA==",
             "dev": true,
             "requires": {
                 "async": "^2.6.1",
                 "compare-versions": "^3.2.1",
                 "fileset": "^2.0.3",
-                "istanbul-lib-coverage": "^2.0.3",
-                "istanbul-lib-hook": "^2.0.3",
-                "istanbul-lib-instrument": "^3.1.0",
-                "istanbul-lib-report": "^2.0.4",
-                "istanbul-lib-source-maps": "^3.0.2",
-                "istanbul-reports": "^2.1.1",
-                "js-yaml": "^3.12.0",
-                "make-dir": "^1.3.0",
+                "istanbul-lib-coverage": "^2.0.4",
+                "istanbul-lib-hook": "^2.0.6",
+                "istanbul-lib-instrument": "^3.2.0",
+                "istanbul-lib-report": "^2.0.7",
+                "istanbul-lib-source-maps": "^3.0.5",
+                "istanbul-reports": "^2.2.2",
+                "js-yaml": "^3.13.0",
+                "make-dir": "^2.1.0",
                 "minimatch": "^3.0.4",
                 "once": "^1.4.0"
             },
             "dependencies": {
-                "async": {
-                    "version": "2.6.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-                    "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "dev": true,
                     "requires": {
-                        "lodash": "^4.17.11"
+                        "ms": "^2.1.1"
                     }
+                },
+                "istanbul-lib-coverage": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+                    "integrity": "sha512-LXTBICkMARVgo579kWDm8SqfB6nvSDKNqIOBEjmJRnL04JvoMHCYGWaMddQnseJYtkEuEvO/sIcOxPLk9gERug==",
+                    "dev": true
+                },
+                "istanbul-lib-instrument": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.2.0.tgz",
+                    "integrity": "sha512-06IM3xShbNW4NgZv5AP4QH0oHqf1/ivFo8eFys0ZjPXHGldHJQWb3riYOKXqmOqfxXBfxu4B+g/iuhOPZH0RJg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/generator": "^7.0.0",
+                        "@babel/parser": "^7.0.0",
+                        "@babel/template": "^7.0.0",
+                        "@babel/traverse": "^7.0.0",
+                        "@babel/types": "^7.0.0",
+                        "istanbul-lib-coverage": "^2.0.4",
+                        "semver": "^6.0.0"
+                    }
+                },
+                "istanbul-lib-source-maps": {
+                    "version": "3.0.5",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.5.tgz",
+                    "integrity": "sha512-eDhZ7r6r1d1zQPVZehLc3D0K14vRba/eBYkz3rw16DLOrrTzve9RmnkcwrrkWVgO1FL3EK5knujVe5S8QHE9xw==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.1.1",
+                        "istanbul-lib-coverage": "^2.0.4",
+                        "make-dir": "^2.1.0",
+                        "rimraf": "^2.6.2",
+                        "source-map": "^0.6.1"
+                    }
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "5.7.0",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+                            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+                    "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
                 }
             }
         },
@@ -2254,9 +2331,9 @@
             "dev": true
         },
         "istanbul-lib-hook": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
-            "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.6.tgz",
+            "integrity": "sha512-829DKONApZ7UCiPXcOYWSgkFXa4+vNYoNOt3F+4uDJLKL1OotAoVwvThoEj1i8jmOj7odbYcR3rnaHu+QroaXg==",
             "dev": true,
             "requires": {
                 "append-transform": "^1.0.0"
@@ -2278,16 +2355,38 @@
             }
         },
         "istanbul-lib-report": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
-            "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.7.tgz",
+            "integrity": "sha512-wLH6beJBFbRBLiTlMOBxmb85cnVM1Vyl36N48e4e/aTKSM3WbOx7zbVIH1SQ537fhhsPbX0/C5JB4qsmyRXXyA==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "^2.0.3",
-                "make-dir": "^1.3.0",
+                "istanbul-lib-coverage": "^2.0.4",
+                "make-dir": "^2.1.0",
                 "supports-color": "^6.0.0"
             },
             "dependencies": {
+                "istanbul-lib-coverage": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+                    "integrity": "sha512-LXTBICkMARVgo579kWDm8SqfB6nvSDKNqIOBEjmJRnL04JvoMHCYGWaMddQnseJYtkEuEvO/sIcOxPLk9gERug==",
+                    "dev": true
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
                 "supports-color": {
                     "version": "6.1.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -2336,9 +2435,9 @@
             }
         },
         "istanbul-reports": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
-            "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.2.tgz",
+            "integrity": "sha512-ZFuTdBQ3PSaPnm02aEA4R6mzQ2AF9w03CYiXADzWbbE48v/EFOWF4MaX4FT0NRdqIk48I7o0RPi+S8TMswaCbQ==",
             "dev": true,
             "requires": {
                 "handlebars": "^4.1.0"
@@ -2870,9 +2969,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-            "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -3056,7 +3155,8 @@
         "lodash": {
             "version": "4.17.11",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "dev": true
         },
         "lodash.sortby": {
             "version": "4.7.0",
@@ -4264,6 +4364,12 @@
                 "extend-shallow": "^3.0.0"
             }
         },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
         "sshpk": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -4729,16 +4835,23 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.3.tgz",
-            "integrity": "sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==",
+            "version": "3.5.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
+            "integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
             "dev": true,
             "optional": true,
             "requires": {
-                "commander": "~2.19.0",
+                "commander": "~2.20.0",
                 "source-map": "~0.6.1"
             },
             "dependencies": {
+                "commander": {
+                    "version": "2.20.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+                    "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+                    "dev": true,
+                    "optional": true
+                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",


### PR DESCRIPTION
#### Description of changes

Fixes 3 high-vulnerability audit warnings from `npm run audit`.

Used `npm run audit-fix`
