### PR TITLE
feat: set up continuous deployment from master with semantic-release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@
 
 #### Pull request checklist
 
-- [ ] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc)
-- [ ] PR contains no breaking changes, OR description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
+- [ ] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
+- [ ] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
 - [ ] (if applicable) Addresses issue: #0000
 - [ ] Added relevant unit tests for your changes. (`npm test`)
 - [ ] Verified code coverage for the changes made.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,8 @@
 
 #### Pull request checklist
 
-- [ ] Addresses an existing issue: Fixes #0000
-- [ ] Added relevant unit test for your changes. (`npm run test`)
+- [ ] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc)
+- [ ] PR contains no breaking changes, OR description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
+- [ ] (if applicable) Addresses issue: #0000
+- [ ] Added relevant unit tests for your changes. (`npm test`)
 - [ ] Verified code coverage for the changes made.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Licensed under the MIT License.
 
 # axe-sarif-converter
 
-[![Build Status](https://dev.azure.com/accessibility-insights/axe-sarif-converter/_apis/build/status/Microsoft.axe-sarif-converter%20-%20CI?branchName=master)](https://dev.azure.com/accessibility-insights/axe-sarif-converter/_build/latest?definitionId=20&branchName=master)
-[![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/accessibility-insights/axe-sarif-converter/20.svg)](https://dev.azure.com/accessibility-insights/axe-sarif-converter/_build/latest?definitionId=20&branchName=master)
+[![Build status](https://dev.azure.com/accessibility-insights/axe-sarif-converter/_apis/build/status/Microsoft.axe-sarif-converter%20-%20CI?branchName=master)](https://dev.azure.com/accessibility-insights/axe-sarif-converter/_build/latest?definitionId=20&branchName=master)
+[![Code coverage](https://img.shields.io/azure-devops/coverage/accessibility-insights/axe-sarif-converter/20.svg)](https://dev.azure.com/accessibility-insights/axe-sarif-converter/_build/latest?definitionId=20&branchName=master)
 [![npm](https://img.shields.io/npm/v/axe-sarif-converter.svg)](https://www.npmjs.com/package/axe-sarif-converter)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 Convert [axe-core](https://github.com/dequelabs/axe-core) accessibility scan results to the [SARIF format](http://sarifweb.azurewebsites.net/).
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,4 +74,4 @@ jobs:
                 command: custom
                 customCommand: run semantic-release
             displayName: npm run semantic-release (master branch only)
-            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['EnableSemanticRelease'], 'true'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,6 @@ jobs:
                 pathtoPublish: '$(System.DefaultWorkingDirectory)/test-results/test_result.sarif'
                 artifactName: 'CodeAnalysisLogs'
             condition: always()
-            continueOnError: true
             displayName: publish sarif results
 
           - task: Npm@1
@@ -69,3 +68,10 @@ jobs:
                 command: custom
                 customCommand: run build
             displayName: npm run build
+
+          - task: Npm@1
+            inputs:
+                command: custom
+                customCommand: run semantic-release
+            displayName: npm run semantic-release (master branch only)
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -410,6 +410,229 @@
                 "@types/yargs": "^12.0.9"
             }
         },
+        "@mrmlnc/readdir-enhanced": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+            "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+            "dev": true,
+            "requires": {
+                "call-me-maybe": "^1.0.1",
+                "glob-to-regexp": "^0.3.0"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+            "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+            "dev": true
+        },
+        "@octokit/endpoint": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-4.0.0.tgz",
+            "integrity": "sha512-b8sptNUekjREtCTJFpOfSIL4SKh65WaakcyxWzRcSPOk5RxkZJ/S8884NGZFxZ+jCB2rDURU66pSHn14cVgWVg==",
+            "dev": true,
+            "requires": {
+                "deepmerge": "3.2.0",
+                "is-plain-object": "^2.0.4",
+                "universal-user-agent": "^2.0.1",
+                "url-template": "^2.0.8"
+            }
+        },
+        "@octokit/request": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-3.0.0.tgz",
+            "integrity": "sha512-DZqmbm66tq+a9FtcKrn0sjrUpi0UaZ9QPUCxxyk/4CJ2rseTMpAWRf6gCwOSUCzZcx/4XVIsDk+kz5BVdaeenA==",
+            "dev": true,
+            "requires": {
+                "@octokit/endpoint": "^4.0.0",
+                "deprecation": "^1.0.1",
+                "is-plain-object": "^2.0.4",
+                "node-fetch": "^2.3.0",
+                "once": "^1.4.0",
+                "universal-user-agent": "^2.0.1"
+            }
+        },
+        "@octokit/rest": {
+            "version": "16.24.1",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.24.1.tgz",
+            "integrity": "sha512-V2GVL+cfuwNTcZ9qtBMOR9pIftWo1AiZIiGvWNmTcIQG5mkj83ZXC+g3w5g0cVXt7Hi+mSOrD2bZ7HJOuouUNg==",
+            "dev": true,
+            "requires": {
+                "@octokit/request": "3.0.0",
+                "atob-lite": "^2.0.0",
+                "before-after-hook": "^1.4.0",
+                "btoa-lite": "^1.0.0",
+                "deprecation": "^1.0.1",
+                "lodash.get": "^4.4.2",
+                "lodash.set": "^4.3.2",
+                "lodash.uniq": "^4.5.0",
+                "octokit-pagination-methods": "^1.1.0",
+                "once": "^1.4.0",
+                "universal-user-agent": "^2.0.0",
+                "url-template": "^2.0.8"
+            }
+        },
+        "@semantic-release/commit-analyzer": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.1.0.tgz",
+            "integrity": "sha512-2lb+t6muGenI86mYGpZYOgITx9L3oZYF697tJoqXeQEk0uw0fm+OkkOuDTBA3Oax9ftoNIrCKv9bwgYvxrbM6w==",
+            "dev": true,
+            "requires": {
+                "conventional-changelog-angular": "^5.0.0",
+                "conventional-commits-filter": "^2.0.0",
+                "conventional-commits-parser": "^3.0.0",
+                "debug": "^4.0.0",
+                "import-from": "^2.1.0",
+                "lodash": "^4.17.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "@semantic-release/error": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
+            "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
+            "dev": true
+        },
+        "@semantic-release/github": {
+            "version": "5.2.10",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-5.2.10.tgz",
+            "integrity": "sha512-z/UwIxKb+EMiJDIy/57MBzJ80ar5H9GJQRyML/ILQ8dlrPwXs7cTyTvC7AesrF7t1mJZtg3ht9Qf9RdtR/LGzw==",
+            "dev": true,
+            "requires": {
+                "@octokit/rest": "^16.13.1",
+                "@semantic-release/error": "^2.2.0",
+                "aggregate-error": "^2.0.0",
+                "bottleneck": "^2.0.1",
+                "debug": "^4.0.0",
+                "dir-glob": "^2.0.0",
+                "fs-extra": "^7.0.0",
+                "globby": "^9.0.0",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1",
+                "issue-parser": "^3.0.0",
+                "lodash": "^4.17.4",
+                "mime": "^2.0.3",
+                "p-filter": "^1.0.0",
+                "p-retry": "^3.0.0",
+                "parse-github-url": "^1.0.1",
+                "url-join": "^4.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "@semantic-release/npm": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.1.4.tgz",
+            "integrity": "sha512-YRl8VTVwnRTl/sVRvTXs1ncYcuvuGrqPEXYy+lUK1YRLq25hkrhIdv3Ju0u1zGLqVCA8qRlF3NzWl7pULJXVog==",
+            "dev": true,
+            "requires": {
+                "@semantic-release/error": "^2.2.0",
+                "aggregate-error": "^2.0.0",
+                "execa": "^1.0.0",
+                "fs-extra": "^7.0.0",
+                "lodash": "^4.17.4",
+                "nerf-dart": "^1.0.0",
+                "normalize-url": "^4.0.0",
+                "npm": "6.5.0",
+                "rc": "^1.2.8",
+                "read-pkg": "^4.0.0",
+                "registry-auth-token": "^3.3.1"
+            },
+            "dependencies": {
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
+                    "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+                    "dev": true,
+                    "requires": {
+                        "normalize-package-data": "^2.3.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@semantic-release/release-notes-generator": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-7.1.4.tgz",
+            "integrity": "sha512-pWPouZujddgb6t61t9iA9G3yIfp3TeQ7bPbV1ixYSeP6L7gI1+Du82fY/OHfEwyifpymLUQW0XnIKgKct5IMMw==",
+            "dev": true,
+            "requires": {
+                "conventional-changelog-angular": "^5.0.0",
+                "conventional-changelog-writer": "^4.0.0",
+                "conventional-commits-filter": "^2.0.0",
+                "conventional-commits-parser": "^3.0.0",
+                "debug": "^4.0.0",
+                "get-stream": "^4.0.0",
+                "import-from": "^2.1.0",
+                "into-stream": "^4.0.0",
+                "lodash": "^4.17.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
         "@types/babel__core": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.0.tgz",
@@ -451,6 +674,23 @@
                 "@babel/types": "^7.3.0"
             }
         },
+        "@types/events": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+            "dev": true
+        },
+        "@types/glob": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+            "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+            "dev": true,
+            "requires": {
+                "@types/events": "*",
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
@@ -478,6 +718,12 @@
             "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
             "dev": true
         },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+            "dev": true
+        },
         "@types/node": {
             "version": "11.13.0",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
@@ -495,6 +741,16 @@
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.11.tgz",
             "integrity": "sha512-IsU1TD+8cQCyG76ZqxP0cVFnofvfzT8p/wO8ENT4jbN/KKN3grsHFgHNl/U+08s33ayX4LwI85cEhYXCOlOkMw==",
             "dev": true
+        },
+        "JSONStream": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "dev": true,
+            "requires": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+            }
         },
         "abab": {
             "version": "2.0.0",
@@ -532,6 +788,25 @@
             "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
             "dev": true
         },
+        "agent-base": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+            "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "^5.0.0"
+            }
+        },
+        "aggregate-error": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-2.2.0.tgz",
+            "integrity": "sha512-E5n+IZkhh22/pFdUvHUU/o9z752lc+7tgHt+FXS/g6BjlbE9249dGmuS/SxIWMPhTljZJkFN+7OXE0+O5+WT8w==",
+            "dev": true,
+            "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^3.0.0"
+            }
+        },
         "ajv": {
             "version": "6.10.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -565,6 +840,12 @@
                 "color-convert": "^1.9.0"
             }
         },
+        "ansicolors": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+            "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+            "dev": true
+        },
         "anymatch": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -593,6 +874,12 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "argv-formatter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+            "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
+            "dev": true
+        },
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -615,6 +902,33 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+            "dev": true
+        },
+        "array-find-index": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "dev": true
+        },
+        "array-ify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+            "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "^1.0.1"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
             "dev": true
         },
         "array-unique": {
@@ -681,6 +995,12 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
+        },
+        "atob-lite": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+            "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
             "dev": true
         },
         "aws-sign2": {
@@ -885,6 +1205,18 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "before-after-hook": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+            "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
+            "dev": true
+        },
+        "bottleneck": {
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.18.0.tgz",
+            "integrity": "sha512-U1xiBRaokw4yEguzikOl0VrnZp6uekjpmfrh6rKtr1D+/jFjYCL6J83ZXlGtlBDwVdTmJJ+4Lg5FpB3xmLSiyA==",
+            "dev": true
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -965,6 +1297,12 @@
                 "node-int64": "^0.4.0"
             }
         },
+        "btoa-lite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+            "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+            "dev": true
+        },
         "buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -994,11 +1332,60 @@
                 "unset-value": "^1.0.0"
             }
         },
+        "call-me-maybe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+            "dev": true
+        },
+        "caller-callsite": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+            "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+            "dev": true,
+            "requires": {
+                "callsites": "^2.0.0"
+            },
+            "dependencies": {
+                "callsites": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+                    "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+                    "dev": true
+                }
+            }
+        },
+        "caller-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+            "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+            "dev": true,
+            "requires": {
+                "caller-callsite": "^2.0.0"
+            }
+        },
         "callsites": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
             "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
             "dev": true
+        },
+        "camelcase": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+            "dev": true
+        },
+        "camelcase-keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+            "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^4.1.0",
+                "map-obj": "^2.0.0",
+                "quick-lru": "^1.0.0"
+            }
         },
         "capture-exit": {
             "version": "2.0.0",
@@ -1007,6 +1394,16 @@
             "dev": true,
             "requires": {
                 "rsvp": "^4.8.4"
+            }
+        },
+        "cardinal": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+            "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+            "dev": true,
+            "requires": {
+                "ansicolors": "~0.3.2",
+                "redeyed": "~2.1.0"
             }
         },
         "caseless": {
@@ -1053,6 +1450,21 @@
                         "is-descriptor": "^0.1.0"
                     }
                 }
+            }
+        },
+        "clean-stack": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.1.0.tgz",
+            "integrity": "sha512-uQWrpRm+iZZUCAp7ZZJQbd4Za9I3AjR/3YTjmcnAtkauaIm/T5CT6U8zVI6e60T6OANqBFAzuR9/HB3NzuZCRA==",
+            "dev": true
+        },
+        "cli-table": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+            "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+            "dev": true,
+            "requires": {
+                "colors": "1.0.3"
             }
         },
         "cliui": {
@@ -1120,6 +1532,12 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
+        "colors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+            "dev": true
+        },
         "combined-stream": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
@@ -1134,6 +1552,16 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
             "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
             "dev": true
+        },
+        "compare-func": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+            "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+            "dev": true,
+            "requires": {
+                "array-ify": "^1.0.0",
+                "dot-prop": "^3.0.0"
+            }
         },
         "compare-versions": {
             "version": "3.4.0",
@@ -1152,6 +1580,59 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
+        },
+        "conventional-changelog-angular": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
+            "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+            "dev": true,
+            "requires": {
+                "compare-func": "^1.3.1",
+                "q": "^1.5.1"
+            }
+        },
+        "conventional-changelog-writer": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.3.tgz",
+            "integrity": "sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==",
+            "dev": true,
+            "requires": {
+                "compare-func": "^1.3.1",
+                "conventional-commits-filter": "^2.0.1",
+                "dateformat": "^3.0.0",
+                "handlebars": "^4.1.0",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "semver": "^5.5.0",
+                "split": "^1.0.0",
+                "through2": "^2.0.0"
+            }
+        },
+        "conventional-commits-filter": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
+            "integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
+            "dev": true,
+            "requires": {
+                "is-subset": "^0.1.1",
+                "modify-values": "^1.0.0"
+            }
+        },
+        "conventional-commits-parser": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
+            "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.4",
+                "is-text-path": "^1.0.0",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "split2": "^2.0.0",
+                "through2": "^2.0.0",
+                "trim-off-newlines": "^1.0.0"
+            }
         },
         "convert-source-map": {
             "version": "1.6.0",
@@ -1173,6 +1654,30 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
+        },
+        "cosmiconfig": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+            "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
+            "dev": true,
+            "requires": {
+                "import-fresh": "^2.0.0",
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.13.0",
+                "parse-json": "^4.0.0"
+            },
+            "dependencies": {
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                }
+            }
         },
         "cross-spawn": {
             "version": "6.0.5",
@@ -1200,6 +1705,15 @@
             "dev": true,
             "requires": {
                 "cssom": "0.3.x"
+            }
+        },
+        "currently-unhandled": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "dev": true,
+            "requires": {
+                "array-find-index": "^1.0.1"
             }
         },
         "dashdash": {
@@ -1235,6 +1749,12 @@
                 }
             }
         },
+        "dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+            "dev": true
+        },
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1250,16 +1770,46 @@
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
+        "decamelize-keys": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+            "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+            "dev": true,
+            "requires": {
+                "decamelize": "^1.1.0",
+                "map-obj": "^1.0.0"
+            },
+            "dependencies": {
+                "map-obj": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                    "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+                    "dev": true
+                }
+            }
+        },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true
+        },
         "deep-is": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "deepmerge": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+            "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
             "dev": true
         },
         "default-require-extensions": {
@@ -1335,6 +1885,12 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
+        "deprecation": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
+            "integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==",
+            "dev": true
+        },
         "detect-newline": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -1353,6 +1909,15 @@
             "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
             "dev": true
         },
+        "dir-glob": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+            "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+            "dev": true,
+            "requires": {
+                "path-type": "^3.0.0"
+            }
+        },
         "domexception": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -1360,6 +1925,24 @@
             "dev": true,
             "requires": {
                 "webidl-conversions": "^4.0.2"
+            }
+        },
+        "dot-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+            "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+            "dev": true,
+            "requires": {
+                "is-obj": "^1.0.0"
+            }
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
             }
         },
         "ecc-jsbn": {
@@ -1379,6 +1962,16 @@
             "dev": true,
             "requires": {
                 "once": "^1.4.0"
+            }
+        },
+        "env-ci": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-3.2.0.tgz",
+            "integrity": "sha512-TFjNiDlXrL8/pfHswdvJGEZzJcq3aBPb8Eka83hlGLwuNw9F9BC9S9ETlkfkItLRT9k5JgpGgeP+rL6/3cEbcw==",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0",
+                "java-properties": "^0.2.9"
             }
         },
         "error-ex": {
@@ -1413,6 +2006,21 @@
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
+            }
+        },
+        "es6-promise": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+            "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "^4.0.3"
             }
         },
         "escape-string-regexp": {
@@ -1647,6 +2255,20 @@
             "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
             "dev": true
         },
+        "fast-glob": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
+            "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
+            "dev": true,
+            "requires": {
+                "@mrmlnc/readdir-enhanced": "^2.2.1",
+                "@nodelib/fs.stat": "^1.1.2",
+                "glob-parent": "^3.1.0",
+                "is-glob": "^4.0.0",
+                "merge2": "^1.2.3",
+                "micromatch": "^3.1.10"
+            }
+        },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -1666,6 +2288,15 @@
             "dev": true,
             "requires": {
                 "bser": "^2.0.0"
+            }
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "fileset": {
@@ -1711,6 +2342,24 @@
                 "pinkie-promise": "^2.0.0"
             }
         },
+        "find-versions": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.1.0.tgz",
+            "integrity": "sha512-NCTfNiVzeE/xL+roNDffGuRbrWI6atI18lTJ22vKp7rs2OhYzMK3W1dIdO2TUndH/QMcacM4d1uWwgcZcHK69Q==",
+            "dev": true,
+            "requires": {
+                "array-uniq": "^2.1.0",
+                "semver-regex": "^2.0.0"
+            },
+            "dependencies": {
+                "array-uniq": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
+                    "integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
+                    "dev": true
+                }
+            }
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1741,6 +2390,27 @@
             "dev": true,
             "requires": {
                 "map-cache": "^0.2.2"
+            }
+        },
+        "from2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
+            }
+        },
+        "fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs.realpath": {
@@ -1785,6 +2455,31 @@
                 "assert-plus": "^1.0.0"
             }
         },
+        "git-log-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+            "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
+            "dev": true,
+            "requires": {
+                "argv-formatter": "~1.0.0",
+                "spawn-error-forwarder": "~1.0.0",
+                "split2": "~1.0.0",
+                "stream-combiner2": "~1.1.1",
+                "through2": "~2.0.0",
+                "traverse": "~0.6.6"
+            },
+            "dependencies": {
+                "split2": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+                    "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
+                    "dev": true,
+                    "requires": {
+                        "through2": "~2.0.0"
+                    }
+                }
+            }
+        },
         "glob": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -1799,11 +2494,62 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "glob-parent": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "dev": true,
+            "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                }
+            }
+        },
+        "glob-to-regexp": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+            "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+            "dev": true
+        },
         "globals": {
             "version": "11.11.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
             "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
             "dev": true
+        },
+        "globby": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+            "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+            "dev": true,
+            "requires": {
+                "@types/glob": "^7.1.1",
+                "array-union": "^1.0.2",
+                "dir-glob": "^2.2.2",
+                "fast-glob": "^2.2.6",
+                "glob": "^7.1.3",
+                "ignore": "^4.0.3",
+                "pify": "^4.0.1",
+                "slash": "^2.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                }
+            }
         },
         "graceful-fs": {
             "version": "4.1.15",
@@ -1923,6 +2669,12 @@
                 }
             }
         },
+        "hook-std": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-1.2.0.tgz",
+            "integrity": "sha512-yntre2dbOAjgQ5yoRykyON0D9T96BfshR8IuiL/r3celeHD8I/76w4qo8m3z99houR4Z678jakV3uXrQdSvW/w==",
+            "dev": true
+        },
         "hosted-git-info": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -1938,6 +2690,27 @@
                 "whatwg-encoding": "^1.0.1"
             }
         },
+        "http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "4",
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1949,6 +2722,33 @@
                 "sshpk": "^1.7.0"
             }
         },
+        "https-proxy-agent": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+            "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.1.0",
+                "debug": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
         "iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1956,6 +2756,31 @@
             "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "ignore": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true
+        },
+        "import-fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+            "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+            "dev": true,
+            "requires": {
+                "caller-path": "^2.0.0",
+                "resolve-from": "^3.0.0"
+            }
+        },
+        "import-from": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+            "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "^3.0.0"
             }
         },
         "import-local": {
@@ -1974,6 +2799,12 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
+        "indent-string": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+            "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+            "dev": true
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1989,6 +2820,22 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
             "dev": true
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
+        },
+        "into-stream": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-4.0.0.tgz",
+            "integrity": "sha512-i29KNyE5r0Y/UQzcQ0IbZO1MYJ53Jn0EcFRZPj5FzWKYH17kDFEOwuA+3jroymOI06SW1dEDnly9A1CAreC5dg==",
+            "dev": true,
+            "requires": {
+                "from2": "^2.1.1",
+                "p-is-promise": "^2.0.0"
+            }
         },
         "invariant": {
             "version": "2.2.4",
@@ -2097,10 +2944,22 @@
                 }
             }
         },
+        "is-directory": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+            "dev": true
+        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
             "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
         },
         "is-fullwidth-code-point": {
@@ -2114,6 +2973,15 @@
             "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
             "integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
             "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
         },
         "is-number": {
             "version": "3.0.0",
@@ -2134,6 +3002,18 @@
                     }
                 }
             }
+        },
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -2159,6 +3039,12 @@
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true
         },
+        "is-subset": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+            "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+            "dev": true
+        },
         "is-symbol": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
@@ -2166,6 +3052,15 @@
             "dev": true,
             "requires": {
                 "has-symbols": "^1.0.0"
+            }
+        },
+        "is-text-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+            "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+            "dev": true,
+            "requires": {
+                "text-extensions": "^1.0.0"
             }
         },
         "is-typedarray": {
@@ -2215,6 +3110,19 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
+        },
+        "issue-parser": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-3.0.1.tgz",
+            "integrity": "sha512-5wdT3EE8Kq38x/hJD8QZCJ9scGoOZ5QnzwXyClkviSWTS+xOCE6hJ0qco3H5n5jCsFqpbofZCcMWqlXJzF72VQ==",
+            "dev": true,
+            "requires": {
+                "lodash.capitalize": "^4.2.1",
+                "lodash.escaperegexp": "^4.1.2",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.uniqby": "^4.7.0"
+            }
         },
         "istanbul-api": {
             "version": "2.1.4",
@@ -2442,6 +3350,12 @@
             "requires": {
                 "handlebars": "^4.1.0"
             }
+        },
+        "java-properties": {
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-0.2.10.tgz",
+            "integrity": "sha512-CpKJh9VRNhS+XqZtg1UMejETGEiqwCGDC/uwPEEQwc2nfdbSm73SIE29TplG2gLYuBOOTNDqxzG6A9NtEPLt0w==",
+            "dev": true
         },
         "jest": {
             "version": "24.6.0",
@@ -3057,6 +3971,21 @@
                 "minimist": "^1.2.0"
             }
         },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+            "dev": true
+        },
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -3158,10 +4087,64 @@
             "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
             "dev": true
         },
+        "lodash.capitalize": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+            "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
+            "dev": true
+        },
+        "lodash.escaperegexp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+            "dev": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+            "dev": true
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+            "dev": true
+        },
+        "lodash.set": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+            "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+            "dev": true
+        },
         "lodash.sortby": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
+        },
+        "lodash.toarray": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+            "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+            "dev": true
+        },
+        "lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+            "dev": true
+        },
+        "lodash.uniqby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+            "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
             "dev": true
         },
         "loose-envify": {
@@ -3172,6 +4155,22 @@
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
+        },
+        "loud-rejection": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "dev": true,
+            "requires": {
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
+            }
+        },
+        "macos-release": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+            "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==",
+            "dev": true
         },
         "make-dir": {
             "version": "1.3.0",
@@ -3220,6 +4219,12 @@
             "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
             "dev": true
         },
+        "map-obj": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+            "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+            "dev": true
+        },
         "map-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3227,6 +4232,26 @@
             "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
+            }
+        },
+        "marked": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
+            "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==",
+            "dev": true
+        },
+        "marked-terminal": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-3.2.0.tgz",
+            "integrity": "sha512-Yr1yVS0BbDG55vx7be1D0mdv+jGs9AW563o/Tt/7FTsId2J0yqhrTeXAqq/Q0DyyXltIn6CSxzesQuFqXgafjQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.1.0",
+                "cardinal": "^2.1.1",
+                "chalk": "^2.4.1",
+                "cli-table": "^0.3.1",
+                "node-emoji": "^1.4.1",
+                "supports-hyperlinks": "^1.0.1"
             }
         },
         "mem": {
@@ -3240,6 +4265,84 @@
                 "p-is-promise": "^2.0.0"
             }
         },
+        "meow": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+            "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+            "dev": true,
+            "requires": {
+                "camelcase-keys": "^4.0.0",
+                "decamelize-keys": "^1.0.0",
+                "loud-rejection": "^1.0.0",
+                "minimist": "^1.1.3",
+                "minimist-options": "^3.0.1",
+                "normalize-package-data": "^2.3.4",
+                "read-pkg-up": "^3.0.0",
+                "redent": "^2.0.0",
+                "trim-newlines": "^2.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "read-pkg-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                    "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^3.0.0"
+                    }
+                }
+            }
+        },
         "merge-stream": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -3248,6 +4351,12 @@
             "requires": {
                 "readable-stream": "^2.0.1"
             }
+        },
+        "merge2": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+            "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
+            "dev": true
         },
         "micromatch": {
             "version": "3.1.10",
@@ -3269,6 +4378,12 @@
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.2"
             }
+        },
+        "mime": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+            "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
+            "dev": true
         },
         "mime-db": {
             "version": "1.38.0",
@@ -3305,6 +4420,16 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
             "dev": true
+        },
+        "minimist-options": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+            "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+            "dev": true,
+            "requires": {
+                "arrify": "^1.0.1",
+                "is-plain-obj": "^1.1.0"
+            }
         },
         "mixin-deep": {
             "version": "1.3.1",
@@ -3344,6 +4469,12 @@
                 }
             }
         },
+        "modify-values": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+            "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+            "dev": true
+        },
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3381,10 +4512,31 @@
             "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
             "dev": true
         },
+        "nerf-dart": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+            "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
+            "dev": true
+        },
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
+        "node-emoji": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+            "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+            "dev": true,
+            "requires": {
+                "lodash.toarray": "^4.4.0"
+            }
+        },
+        "node-fetch": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+            "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
             "dev": true
         },
         "node-int64": {
@@ -3431,6 +4583,3112 @@
             "dev": true,
             "requires": {
                 "remove-trailing-separator": "^1.0.1"
+            }
+        },
+        "normalize-url": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+            "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+            "dev": true
+        },
+        "npm": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-6.5.0.tgz",
+            "integrity": "sha512-SPq8zG2Kto+Xrq55E97O14Jla13PmQT5kSnvwBj88BmJZ5Nvw++OmlWfhjkB67pcgP5UEXljEtnGFKZtOgt6MQ==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.3.4",
+                "abbrev": "~1.1.1",
+                "ansicolors": "~0.3.2",
+                "ansistyles": "~0.1.3",
+                "aproba": "~1.2.0",
+                "archy": "~1.0.0",
+                "bin-links": "^1.1.2",
+                "bluebird": "^3.5.3",
+                "byte-size": "^4.0.3",
+                "cacache": "^11.2.0",
+                "call-limit": "~1.1.0",
+                "chownr": "~1.0.1",
+                "ci-info": "^1.6.0",
+                "cli-columns": "^3.1.2",
+                "cli-table3": "^0.5.0",
+                "cmd-shim": "~2.0.2",
+                "columnify": "~1.5.4",
+                "config-chain": "^1.1.12",
+                "debuglog": "*",
+                "detect-indent": "~5.0.0",
+                "detect-newline": "^2.1.0",
+                "dezalgo": "~1.0.3",
+                "editor": "~1.0.0",
+                "figgy-pudding": "^3.5.1",
+                "find-npm-prefix": "^1.0.2",
+                "fs-vacuum": "~1.2.10",
+                "fs-write-stream-atomic": "~1.0.10",
+                "gentle-fs": "^2.0.1",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.1.15",
+                "has-unicode": "~2.0.1",
+                "hosted-git-info": "^2.7.1",
+                "iferr": "^1.0.2",
+                "imurmurhash": "*",
+                "inflight": "~1.0.6",
+                "inherits": "~2.0.3",
+                "ini": "^1.3.5",
+                "init-package-json": "^1.10.3",
+                "is-cidr": "^2.0.6",
+                "json-parse-better-errors": "^1.0.2",
+                "lazy-property": "~1.0.0",
+                "libcipm": "^2.0.2",
+                "libnpmhook": "^4.0.1",
+                "libnpx": "^10.2.0",
+                "lock-verify": "^2.0.2",
+                "lockfile": "^1.0.4",
+                "lodash._baseindexof": "*",
+                "lodash._baseuniq": "~4.6.0",
+                "lodash._bindcallback": "*",
+                "lodash._cacheindexof": "*",
+                "lodash._createcache": "*",
+                "lodash._getnative": "*",
+                "lodash.clonedeep": "~4.5.0",
+                "lodash.restparam": "*",
+                "lodash.union": "~4.6.0",
+                "lodash.uniq": "~4.5.0",
+                "lodash.without": "~4.4.0",
+                "lru-cache": "^4.1.3",
+                "meant": "~1.0.1",
+                "mississippi": "^3.0.0",
+                "mkdirp": "~0.5.1",
+                "move-concurrently": "^1.0.1",
+                "node-gyp": "^3.8.0",
+                "nopt": "~4.0.1",
+                "normalize-package-data": "~2.4.0",
+                "npm-audit-report": "^1.3.1",
+                "npm-cache-filename": "~1.0.2",
+                "npm-install-checks": "~3.0.0",
+                "npm-lifecycle": "^2.1.0",
+                "npm-package-arg": "^6.1.0",
+                "npm-packlist": "^1.1.12",
+                "npm-pick-manifest": "^2.1.0",
+                "npm-profile": "^3.0.2",
+                "npm-registry-client": "^8.6.0",
+                "npm-registry-fetch": "^1.1.0",
+                "npm-user-validate": "~1.0.0",
+                "npmlog": "~4.1.2",
+                "once": "~1.4.0",
+                "opener": "^1.5.1",
+                "osenv": "^0.1.5",
+                "pacote": "^8.1.6",
+                "path-is-inside": "~1.0.2",
+                "promise-inflight": "~1.0.1",
+                "qrcode-terminal": "^0.12.0",
+                "query-string": "^6.1.0",
+                "qw": "~1.0.1",
+                "read": "~1.0.7",
+                "read-cmd-shim": "~1.0.1",
+                "read-installed": "~4.0.3",
+                "read-package-json": "^2.0.13",
+                "read-package-tree": "^5.2.1",
+                "readable-stream": "^2.3.6",
+                "readdir-scoped-modules": "*",
+                "request": "^2.88.0",
+                "retry": "^0.12.0",
+                "rimraf": "~2.6.2",
+                "safe-buffer": "^5.1.2",
+                "semver": "^5.5.1",
+                "sha": "~2.0.1",
+                "slide": "~1.1.6",
+                "sorted-object": "~2.0.1",
+                "sorted-union-stream": "~2.1.3",
+                "ssri": "^6.0.1",
+                "stringify-package": "^1.0.0",
+                "tar": "^4.4.8",
+                "text-table": "~0.2.0",
+                "tiny-relative-date": "^1.3.0",
+                "uid-number": "0.0.6",
+                "umask": "~1.1.0",
+                "unique-filename": "~1.1.0",
+                "unpipe": "~1.0.0",
+                "update-notifier": "^2.5.0",
+                "uuid": "^3.3.2",
+                "validate-npm-package-license": "^3.0.4",
+                "validate-npm-package-name": "~3.0.0",
+                "which": "^1.3.1",
+                "worker-farm": "^1.6.0",
+                "write-file-atomic": "^2.3.0"
+            },
+            "dependencies": {
+                "JSONStream": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "jsonparse": "^1.2.0",
+                        "through": ">=2.2.7 <3"
+                    }
+                },
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "agent-base": {
+                    "version": "4.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "es6-promisify": "^5.0.0"
+                    }
+                },
+                "agentkeepalive": {
+                    "version": "3.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "humanize-ms": "^1.2.1"
+                    }
+                },
+                "ajv": {
+                    "version": "5.5.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
+                    }
+                },
+                "ansi-align": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.0.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "ansicolors": {
+                    "version": "0.3.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansistyles": {
+                    "version": "0.1.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "archy": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    }
+                },
+                "asap": {
+                    "version": "2.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "asn1": {
+                    "version": "0.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": "~2.1.0"
+                    }
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aws4": {
+                    "version": "1.8.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "^0.14.3"
+                    }
+                },
+                "bin-links": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "^3.5.0",
+                        "cmd-shim": "^2.0.2",
+                        "gentle-fs": "^2.0.0",
+                        "graceful-fs": "^4.1.11",
+                        "write-file-atomic": "^2.3.0"
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "~2.0.0"
+                    }
+                },
+                "bluebird": {
+                    "version": "3.5.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "boxen": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-align": "^2.0.0",
+                        "camelcase": "^4.0.0",
+                        "chalk": "^2.0.1",
+                        "cli-boxes": "^1.0.0",
+                        "string-width": "^2.0.0",
+                        "term-size": "^1.2.0",
+                        "widest-line": "^2.0.0"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-from": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "builtin-modules": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "builtins": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "byline": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "byte-size": {
+                    "version": "4.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cacache": {
+                    "version": "11.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "^3.5.1",
+                        "chownr": "^1.0.1",
+                        "figgy-pudding": "^3.1.0",
+                        "glob": "^7.1.2",
+                        "graceful-fs": "^4.1.11",
+                        "lru-cache": "^4.1.3",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "move-concurrently": "^1.0.1",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^2.6.2",
+                        "ssri": "^6.0.0",
+                        "unique-filename": "^1.1.0",
+                        "y18n": "^4.0.0"
+                    }
+                },
+                "call-limit": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "capture-stack-trace": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "chownr": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ci-info": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cidr-regex": {
+                    "version": "2.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ip-regex": "^2.1.0"
+                    }
+                },
+                "cli-boxes": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cli-columns": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.0.0",
+                        "strip-ansi": "^3.0.1"
+                    }
+                },
+                "cli-table3": {
+                    "version": "0.5.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "colors": "^1.1.2",
+                        "object-assign": "^4.1.0",
+                        "string-width": "^2.1.1"
+                    }
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "clone": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cmd-shim": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "~0.5.0"
+                    }
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "color-convert": {
+                    "version": "1.9.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "color-name": "^1.1.1"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "colors": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "columnify": {
+                    "version": "1.5.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "strip-ansi": "^3.0.0",
+                        "wcwidth": "^1.0.0"
+                    }
+                },
+                "combined-stream": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "~1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-stream": {
+                    "version": "1.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
+                    }
+                },
+                "config-chain": {
+                    "version": "1.1.12",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ini": "^1.3.4",
+                        "proto-list": "~1.2.1"
+                    }
+                },
+                "configstore": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "dot-prop": "^4.1.0",
+                        "graceful-fs": "^4.1.2",
+                        "make-dir": "^1.0.0",
+                        "unique-string": "^1.0.0",
+                        "write-file-atomic": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
+                    }
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "copy-concurrently": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.1.1",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "iferr": "^0.1.5",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "iferr": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "create-error-class": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "capture-stack-trace": "^1.0.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "crypto-random-string": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cyclist": {
+                    "version": "0.2.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "debuglog": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "decode-uri-component": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "deep-extend": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "defaults": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "clone": "^1.0.2"
+                    }
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "detect-indent": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "detect-newline": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "dezalgo": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "asap": "^2.0.0",
+                        "wrappy": "1"
+                    }
+                },
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-obj": "^1.0.0"
+                    }
+                },
+                "dotenv": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "duplexer3": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "duplexify": {
+                    "version": "3.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
+                    }
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "~0.1.0",
+                        "safer-buffer": "^2.1.0"
+                    }
+                },
+                "editor": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "encoding": {
+                    "version": "0.1.12",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "iconv-lite": "~0.4.13"
+                    }
+                },
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.4.0"
+                    }
+                },
+                "err-code": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "errno": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "prr": "~1.0.1"
+                    }
+                },
+                "es6-promise": {
+                    "version": "4.2.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "es6-promisify": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "es6-promise": "^4.0.3"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "extsprintf": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fast-deep-equal": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fast-json-stable-stringify": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "figgy-pudding": {
+                    "version": "3.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "find-npm-prefix": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "flush-write-stream": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
+                    }
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "form-data": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "from2": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
+                    }
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "fs-vacuum": {
+                    "version": "1.2.10",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "path-is-inside": "^1.0.1",
+                        "rimraf": "^2.5.2"
+                    }
+                },
+                "fs-write-stream-atomic": {
+                    "version": "1.0.10",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "iferr": "^0.1.5",
+                        "imurmurhash": "^0.1.4",
+                        "readable-stream": "1 || 2"
+                    },
+                    "dependencies": {
+                        "iferr": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "genfun": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "gentle-fs": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.1.2",
+                        "fs-vacuum": "^1.2.10",
+                        "graceful-fs": "^4.1.11",
+                        "iferr": "^0.1.5",
+                        "mkdirp": "^0.5.1",
+                        "path-is-inside": "^1.0.2",
+                        "read-cmd-shim": "^1.0.1",
+                        "slide": "^1.1.6"
+                    },
+                    "dependencies": {
+                        "iferr": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "get-caller-file": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "global-dirs": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ini": "^1.3.4"
+                    }
+                },
+                "got": {
+                    "version": "6.7.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.15",
+                    "bundled": true,
+                    "dev": true
+                },
+                "har-schema": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "har-validator": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^5.3.0",
+                        "har-schema": "^2.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "hosted-git-info": {
+                    "version": "2.7.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "http-cache-semantics": {
+                    "version": "3.8.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "http-proxy-agent": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "4",
+                        "debug": "3.1.0"
+                    }
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^4.1.0",
+                        "debug": "^3.1.0"
+                    }
+                },
+                "humanize-ms": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.0.0"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.4.23",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
+                "iferr": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "import-lazy": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "init-package-json": {
+                    "version": "1.10.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.1",
+                        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+                        "promzard": "^0.3.0",
+                        "read": "~1.0.1",
+                        "read-package-json": "1 || 2",
+                        "semver": "2.x || 3.x || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1",
+                        "validate-npm-package-name": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ip": {
+                    "version": "1.1.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ip-regex": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-builtin-module": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "builtin-modules": "^1.0.0"
+                    }
+                },
+                "is-ci": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^1.0.0"
+                    }
+                },
+                "is-cidr": {
+                    "version": "2.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cidr-regex": "^2.0.8"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "is-installed-globally": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "global-dirs": "^0.1.0",
+                        "is-path-inside": "^1.0.0"
+                    }
+                },
+                "is-npm": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-obj": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-path-inside": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-is-inside": "^1.0.1"
+                    }
+                },
+                "is-redirect": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-retry-allowed": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-parse-better-errors": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.3.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "jsonparse": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "jsprim": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.3.0",
+                        "json-schema": "0.2.3",
+                        "verror": "1.10.0"
+                    }
+                },
+                "latest-version": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "package-json": "^4.0.0"
+                    }
+                },
+                "lazy-property": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^1.0.0"
+                    }
+                },
+                "libcipm": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "bin-links": "^1.1.2",
+                        "bluebird": "^3.5.1",
+                        "find-npm-prefix": "^1.0.2",
+                        "graceful-fs": "^4.1.11",
+                        "lock-verify": "^2.0.2",
+                        "mkdirp": "^0.5.1",
+                        "npm-lifecycle": "^2.0.3",
+                        "npm-logical-tree": "^1.2.1",
+                        "npm-package-arg": "^6.1.0",
+                        "pacote": "^8.1.6",
+                        "protoduck": "^5.0.0",
+                        "read-package-json": "^2.0.13",
+                        "rimraf": "^2.6.2",
+                        "worker-farm": "^1.6.0"
+                    }
+                },
+                "libnpmhook": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "figgy-pudding": "^3.1.0",
+                        "npm-registry-fetch": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "npm-registry-fetch": {
+                            "version": "3.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "bluebird": "^3.5.1",
+                                "figgy-pudding": "^3.1.0",
+                                "lru-cache": "^4.1.2",
+                                "make-fetch-happen": "^4.0.0",
+                                "npm-package-arg": "^6.0.0"
+                            }
+                        }
+                    }
+                },
+                "libnpx": {
+                    "version": "10.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "dotenv": "^5.0.1",
+                        "npm-package-arg": "^6.0.0",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.0",
+                        "update-notifier": "^2.3.0",
+                        "which": "^1.3.0",
+                        "y18n": "^4.0.0",
+                        "yargs": "^11.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "lock-verify": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "npm-package-arg": "^5.1.2 || 6",
+                        "semver": "^5.4.1"
+                    }
+                },
+                "lockfile": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "lodash._baseindexof": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash._baseuniq": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lodash._createset": "~4.0.0",
+                        "lodash._root": "~3.0.0"
+                    }
+                },
+                "lodash._bindcallback": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash._cacheindexof": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash._createcache": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lodash._getnative": "^3.0.0"
+                    }
+                },
+                "lodash._createset": {
+                    "version": "4.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash._getnative": {
+                    "version": "3.9.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash._root": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.clonedeep": {
+                    "version": "4.5.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.restparam": {
+                    "version": "3.6.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.union": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.uniq": {
+                    "version": "4.5.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.without": {
+                    "version": "4.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lowercase-keys": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "4.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "make-dir": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "make-fetch-happen": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agentkeepalive": "^3.4.1",
+                        "cacache": "^11.0.1",
+                        "http-cache-semantics": "^3.8.1",
+                        "http-proxy-agent": "^2.1.0",
+                        "https-proxy-agent": "^2.2.1",
+                        "lru-cache": "^4.1.2",
+                        "mississippi": "^3.0.0",
+                        "node-fetch-npm": "^2.0.2",
+                        "promise-retry": "^1.1.1",
+                        "socks-proxy-agent": "^4.0.0",
+                        "ssri": "^6.0.0"
+                    }
+                },
+                "meant": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mem": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "mime-db": {
+                    "version": "1.35.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.19",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "~1.35.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minipass": {
+                    "version": "2.3.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "yallist": {
+                            "version": "3.0.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "minizlib": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "mississippi": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^3.0.0",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "move-concurrently": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.1.1",
+                        "copy-concurrently": "^1.0.0",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.3"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mute-stream": {
+                    "version": "0.0.7",
+                    "bundled": true,
+                    "dev": true
+                },
+                "node-fetch-npm": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "encoding": "^0.1.11",
+                        "json-parse-better-errors": "^1.0.0",
+                        "safe-buffer": "^5.1.1"
+                    }
+                },
+                "node-gyp": {
+                    "version": "3.8.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fstream": "^1.0.0",
+                        "glob": "^7.0.3",
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "^0.5.0",
+                        "nopt": "2 || 3",
+                        "npmlog": "0 || 1 || 2 || 3 || 4",
+                        "osenv": "0",
+                        "request": "^2.87.0",
+                        "rimraf": "2",
+                        "semver": "~5.3.0",
+                        "tar": "^2.0.0",
+                        "which": "1"
+                    },
+                    "dependencies": {
+                        "nopt": {
+                            "version": "3.0.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "abbrev": "1"
+                            }
+                        },
+                        "semver": {
+                            "version": "5.3.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "tar": {
+                            "version": "2.2.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "block-stream": "*",
+                                "fstream": "^1.0.2",
+                                "inherits": "2"
+                            }
+                        }
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
+                "normalize-package-data": {
+                    "version": "2.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^2.1.4",
+                        "is-builtin-module": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
+                    }
+                },
+                "npm-audit-report": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cli-table3": "^0.5.0",
+                        "console-control-strings": "^1.1.0"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npm-cache-filename": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npm-install-checks": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "semver": "^2.3.0 || 3.x || 4 || 5"
+                    }
+                },
+                "npm-lifecycle": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "byline": "^5.0.0",
+                        "graceful-fs": "^4.1.11",
+                        "node-gyp": "^3.8.0",
+                        "resolve-from": "^4.0.0",
+                        "slide": "^1.1.6",
+                        "uid-number": "0.0.6",
+                        "umask": "^1.1.0",
+                        "which": "^1.3.1"
+                    }
+                },
+                "npm-logical-tree": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npm-package-arg": {
+                    "version": "6.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^2.6.0",
+                        "osenv": "^0.1.5",
+                        "semver": "^5.5.0",
+                        "validate-npm-package-name": "^3.0.0"
+                    }
+                },
+                "npm-packlist": {
+                    "version": "1.1.12",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npm-pick-manifest": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "npm-package-arg": "^6.0.0",
+                        "semver": "^5.4.1"
+                    }
+                },
+                "npm-profile": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.1.2 || 2",
+                        "make-fetch-happen": "^2.5.0 || 3 || 4"
+                    }
+                },
+                "npm-registry-client": {
+                    "version": "8.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "concat-stream": "^1.5.2",
+                        "graceful-fs": "^4.1.6",
+                        "normalize-package-data": "~1.0.1 || ^2.0.0",
+                        "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+                        "npmlog": "2 || ^3.1.0 || ^4.0.0",
+                        "once": "^1.3.3",
+                        "request": "^2.74.0",
+                        "retry": "^0.10.0",
+                        "safe-buffer": "^5.1.1",
+                        "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+                        "slide": "^1.1.3",
+                        "ssri": "^5.2.4"
+                    },
+                    "dependencies": {
+                        "retry": {
+                            "version": "0.10.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ssri": {
+                            "version": "5.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.1"
+                            }
+                        }
+                    }
+                },
+                "npm-registry-fetch": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "^3.5.1",
+                        "figgy-pudding": "^2.0.1",
+                        "lru-cache": "^4.1.2",
+                        "make-fetch-happen": "^3.0.0",
+                        "npm-package-arg": "^6.0.0",
+                        "safe-buffer": "^5.1.1"
+                    },
+                    "dependencies": {
+                        "cacache": {
+                            "version": "10.0.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "bluebird": "^3.5.1",
+                                "chownr": "^1.0.1",
+                                "glob": "^7.1.2",
+                                "graceful-fs": "^4.1.11",
+                                "lru-cache": "^4.1.1",
+                                "mississippi": "^2.0.0",
+                                "mkdirp": "^0.5.1",
+                                "move-concurrently": "^1.0.1",
+                                "promise-inflight": "^1.0.1",
+                                "rimraf": "^2.6.2",
+                                "ssri": "^5.2.4",
+                                "unique-filename": "^1.1.0",
+                                "y18n": "^4.0.0"
+                            },
+                            "dependencies": {
+                                "mississippi": {
+                                    "version": "2.0.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "concat-stream": "^1.5.0",
+                                        "duplexify": "^3.4.2",
+                                        "end-of-stream": "^1.1.0",
+                                        "flush-write-stream": "^1.0.0",
+                                        "from2": "^2.1.0",
+                                        "parallel-transform": "^1.1.0",
+                                        "pump": "^2.0.1",
+                                        "pumpify": "^1.3.3",
+                                        "stream-each": "^1.1.0",
+                                        "through2": "^2.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "figgy-pudding": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "make-fetch-happen": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "agentkeepalive": "^3.4.1",
+                                "cacache": "^10.0.4",
+                                "http-cache-semantics": "^3.8.1",
+                                "http-proxy-agent": "^2.1.0",
+                                "https-proxy-agent": "^2.2.0",
+                                "lru-cache": "^4.1.2",
+                                "mississippi": "^3.0.0",
+                                "node-fetch-npm": "^2.0.2",
+                                "promise-retry": "^1.1.1",
+                                "socks-proxy-agent": "^3.0.1",
+                                "ssri": "^5.2.4"
+                            }
+                        },
+                        "pump": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "end-of-stream": "^1.1.0",
+                                "once": "^1.3.1"
+                            }
+                        },
+                        "smart-buffer": {
+                            "version": "1.1.15",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "socks": {
+                            "version": "1.1.10",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ip": "^1.1.4",
+                                "smart-buffer": "^1.0.13"
+                            }
+                        },
+                        "socks-proxy-agent": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "agent-base": "^4.1.0",
+                                "socks": "^1.1.10"
+                            }
+                        },
+                        "ssri": {
+                            "version": "5.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.1"
+                            }
+                        }
+                    }
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^2.0.0"
+                    }
+                },
+                "npm-user-validate": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.9.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "opener": {
+                    "version": "1.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
+                    }
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "package-json": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "got": "^6.7.1",
+                        "registry-auth-token": "^3.0.1",
+                        "registry-url": "^3.0.3",
+                        "semver": "^5.1.0"
+                    }
+                },
+                "pacote": {
+                    "version": "8.1.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "^3.5.1",
+                        "cacache": "^11.0.2",
+                        "get-stream": "^3.0.0",
+                        "glob": "^7.1.2",
+                        "lru-cache": "^4.1.3",
+                        "make-fetch-happen": "^4.0.1",
+                        "minimatch": "^3.0.4",
+                        "minipass": "^2.3.3",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "normalize-package-data": "^2.4.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-packlist": "^1.1.10",
+                        "npm-pick-manifest": "^2.1.0",
+                        "osenv": "^0.1.5",
+                        "promise-inflight": "^1.0.1",
+                        "promise-retry": "^1.1.1",
+                        "protoduck": "^5.0.0",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.2",
+                        "semver": "^5.5.0",
+                        "ssri": "^6.0.0",
+                        "tar": "^4.4.3",
+                        "unique-filename": "^1.1.0",
+                        "which": "^1.3.0"
+                    }
+                },
+                "parallel-transform": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-is-inside": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "prepend-http": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "promise-inflight": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "promise-retry": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "err-code": "^1.0.0",
+                        "retry": "^0.10.0"
+                    },
+                    "dependencies": {
+                        "retry": {
+                            "version": "0.10.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "promzard": {
+                    "version": "0.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "read": "1"
+                    }
+                },
+                "proto-list": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "protoduck": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "genfun": "^4.0.1"
+                    }
+                },
+                "prr": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "psl": {
+                    "version": "1.1.29",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                },
+                "pumpify": {
+                    "version": "1.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "duplexify": "^3.6.0",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "pump": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "end-of-stream": "^1.1.0",
+                                "once": "^1.3.1"
+                            }
+                        }
+                    }
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "qrcode-terminal": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "query-string": {
+                    "version": "6.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "decode-uri-component": "^0.2.0",
+                        "strict-uri-encode": "^2.0.0"
+                    }
+                },
+                "qw": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "rc": {
+                    "version": "1.2.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "read": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mute-stream": "~0.0.4"
+                    }
+                },
+                "read-cmd-shim": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2"
+                    }
+                },
+                "read-installed": {
+                    "version": "4.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "debuglog": "^1.0.1",
+                        "graceful-fs": "^4.1.2",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "slide": "~1.1.3",
+                        "util-extend": "^1.0.1"
+                    }
+                },
+                "read-package-json": {
+                    "version": "2.0.13",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "json-parse-better-errors": "^1.0.1",
+                        "normalize-package-data": "^2.0.0",
+                        "slash": "^1.0.0"
+                    }
+                },
+                "read-package-tree": {
+                    "version": "5.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "once": "^1.3.0",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "readdir-scoped-modules": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "graceful-fs": "^4.1.2",
+                        "once": "^1.3.0"
+                    }
+                },
+                "registry-auth-token": {
+                    "version": "3.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "rc": "^1.1.6",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "registry-url": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "rc": "^1.0.1"
+                    }
+                },
+                "request": {
+                    "version": "2.88.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
+                    }
+                },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "retry": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.0.5"
+                    }
+                },
+                "run-queue": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "aproba": "^1.1.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver-diff": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "semver": "^5.0.3"
+                    }
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "sha": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "readable-stream": "^2.0.2"
+                    }
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "slash": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "slide": {
+                    "version": "1.1.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "smart-buffer": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "socks": {
+                    "version": "2.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ip": "^1.1.5",
+                        "smart-buffer": "^4.0.1"
+                    }
+                },
+                "socks-proxy-agent": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "~4.2.0",
+                        "socks": "~2.2.0"
+                    }
+                },
+                "sorted-object": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "sorted-union-stream": {
+                    "version": "2.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "from2": "^1.3.0",
+                        "stream-iterate": "^1.1.0"
+                    },
+                    "dependencies": {
+                        "from2": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "inherits": "~2.0.1",
+                                "readable-stream": "~1.1.10"
+                            }
+                        },
+                        "isarray": {
+                            "version": "0.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "readable-stream": {
+                            "version": "1.1.14",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
+                                "isarray": "0.0.1",
+                                "string_decoder": "~0.10.x"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "0.10.31",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "spdx-correct": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-exceptions": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "spdx-expression-parse": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-license-ids": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "sshpk": {
+                    "version": "1.14.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jsbn": "~0.1.0",
+                        "safer-buffer": "^2.0.2",
+                        "tweetnacl": "~0.14.0"
+                    }
+                },
+                "ssri": {
+                    "version": "6.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1"
+                    }
+                },
+                "stream-each": {
+                    "version": "1.2.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
+                    }
+                },
+                "stream-iterate": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "^2.1.5",
+                        "stream-shift": "^1.0.0"
+                    }
+                },
+                "stream-shift": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strict-uri-encode": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "stringify-package": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "tar": {
+                    "version": "4.4.8",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "chownr": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "minipass": {
+                            "version": "2.3.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
+                        },
+                        "yallist": {
+                            "version": "3.0.3",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "term-size": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0"
+                    }
+                },
+                "text-table": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "through": {
+                    "version": "2.3.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
+                    }
+                },
+                "timed-out": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "tiny-relative-date": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "typedarray": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "umask": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "unique-filename": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "unique-slug": "^2.0.0"
+                    }
+                },
+                "unique-slug": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "imurmurhash": "^0.1.4"
+                    }
+                },
+                "unique-string": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "crypto-random-string": "^1.0.0"
+                    }
+                },
+                "unpipe": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "unzip-response": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "update-notifier": {
+                    "version": "2.5.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "boxen": "^1.2.1",
+                        "chalk": "^2.0.1",
+                        "configstore": "^3.0.0",
+                        "import-lazy": "^2.1.0",
+                        "is-ci": "^1.0.10",
+                        "is-installed-globally": "^0.1.0",
+                        "is-npm": "^1.0.0",
+                        "latest-version": "^3.0.0",
+                        "semver-diff": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
+                    }
+                },
+                "url-parse-lax": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "prepend-http": "^1.0.1"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "util-extend": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.3.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
+                    }
+                },
+                "validate-npm-package-name": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "builtins": "^1.0.3"
+                    }
+                },
+                "verror": {
+                    "version": "1.10.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "^1.2.0"
+                    }
+                },
+                "wcwidth": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "defaults": "^1.0.3"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.2"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "widest-line": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1"
+                    }
+                },
+                "worker-farm": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "errno": "~0.1.7"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "write-file-atomic": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "xdg-basedir": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "xtend": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "11.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
+                    },
+                    "dependencies": {
+                        "y18n": {
+                            "version": "3.2.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "yargs-parser": {
+                    "version": "9.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
+                    }
+                }
             }
         },
         "npm-run-path": {
@@ -3531,6 +7789,12 @@
                 "isobject": "^3.0.1"
             }
         },
+        "octokit-pagination-methods": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+            "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+            "dev": true
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3591,6 +7855,16 @@
                 "mem": "^4.0.0"
             }
         },
+        "os-name": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+            "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+            "dev": true,
+            "requires": {
+                "macos-release": "^2.2.0",
+                "windows-release": "^3.1.0"
+            }
+        },
         "p-defer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -3604,6 +7878,15 @@
             "dev": true,
             "requires": {
                 "p-reduce": "^1.0.0"
+            }
+        },
+        "p-filter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-1.0.0.tgz",
+            "integrity": "sha1-Yp0xcVAgnI/VCLoTdxPvS7kg6ds=",
+            "dev": true,
+            "requires": {
+                "p-map": "^1.0.0"
             }
         },
         "p-finally": {
@@ -3636,16 +7919,37 @@
                 "p-limit": "^2.0.0"
             }
         },
+        "p-map": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+            "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+            "dev": true
+        },
         "p-reduce": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
             "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
             "dev": true
         },
+        "p-retry": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
+            "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+            "dev": true,
+            "requires": {
+                "retry": "^0.12.0"
+            }
+        },
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true
+        },
+        "parse-github-url": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+            "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
             "dev": true
         },
         "parse-json": {
@@ -3667,6 +7971,12 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
             "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
             "dev": true
         },
         "path-exists": {
@@ -3695,6 +8005,23 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
+        },
+        "path-type": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
+            }
         },
         "performance-now": {
             "version": "2.1.0",
@@ -3846,17 +8173,109 @@
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
             "dev": true
         },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
+        "quick-lru": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+            "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+            "dev": true
+        },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            }
+        },
         "react-is": {
             "version": "16.8.6",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
             "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
             "dev": true
+        },
+        "read-pkg": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+            },
+            "dependencies": {
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                }
+            }
+        },
+        "read-pkg-up": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+            "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                }
+            }
         },
         "readable-stream": {
             "version": "2.3.6",
@@ -3882,6 +8301,25 @@
                 "util.promisify": "^1.0.0"
             }
         },
+        "redent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+            "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+            "dev": true,
+            "requires": {
+                "indent-string": "^3.0.0",
+                "strip-indent": "^2.0.0"
+            }
+        },
+        "redeyed": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+            "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
+            "dev": true,
+            "requires": {
+                "esprima": "~4.0.0"
+            }
+        },
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -3890,6 +8328,16 @@
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
+            }
+        },
+        "registry-auth-token": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+            "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+            "dev": true,
+            "requires": {
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "remove-trailing-separator": {
@@ -4024,6 +8472,12 @@
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
         },
+        "retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+            "dev": true
+        },
         "rimraf": {
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -4099,10 +8553,73 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
             "dev": true
         },
+        "semantic-release": {
+            "version": "15.13.3",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.13.3.tgz",
+            "integrity": "sha512-cax0xPPTtsxHlrty2HxhPql2TTvS74Ni2O8BzwFHxNY/mviVKEhI4OxHzBYJkpVxx1fMVj36+oH7IlP+SJtPNA==",
+            "dev": true,
+            "requires": {
+                "@semantic-release/commit-analyzer": "^6.1.0",
+                "@semantic-release/error": "^2.2.0",
+                "@semantic-release/github": "^5.1.0",
+                "@semantic-release/npm": "^5.0.5",
+                "@semantic-release/release-notes-generator": "^7.1.2",
+                "aggregate-error": "^2.0.0",
+                "cosmiconfig": "^5.0.1",
+                "debug": "^4.0.0",
+                "env-ci": "^3.0.0",
+                "execa": "^1.0.0",
+                "figures": "^2.0.0",
+                "find-versions": "^3.0.0",
+                "get-stream": "^4.0.0",
+                "git-log-parser": "^1.2.0",
+                "hook-std": "^1.1.0",
+                "hosted-git-info": "^2.7.1",
+                "lodash": "^4.17.4",
+                "marked": "^0.6.0",
+                "marked-terminal": "^3.2.0",
+                "p-locate": "^3.0.0",
+                "p-reduce": "^1.0.0",
+                "read-pkg-up": "^4.0.0",
+                "resolve-from": "^4.0.0",
+                "semver": "^5.4.1",
+                "signale": "^1.2.1",
+                "yargs": "^12.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
+        },
         "semver": {
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+            "dev": true
+        },
+        "semver-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+            "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
             "dev": true
         },
         "set-blocking": {
@@ -4160,6 +8677,112 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
+        },
+        "signale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+            "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.3.2",
+                "figures": "^2.0.0",
+                "pkg-conf": "^2.1.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                },
+                "pkg-conf": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+                    "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^2.0.0",
+                        "load-json-file": "^4.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                }
+            }
         },
         "sisteransi": {
             "version": "1.0.0",
@@ -4323,6 +8946,12 @@
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
             "dev": true
         },
+        "spawn-error-forwarder": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+            "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk=",
+            "dev": true
+        },
         "spdx-correct": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -4355,6 +8984,15 @@
             "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
             "dev": true
         },
+        "split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "dev": true,
+            "requires": {
+                "through": "2"
+            }
+        },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4362,6 +9000,15 @@
             "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
+            }
+        },
+        "split2": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+            "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.2"
             }
         },
         "sprintf-js": {
@@ -4419,6 +9066,16 @@
             "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
             "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
             "dev": true
+        },
+        "stream-combiner2": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "~0.1.0",
+                "readable-stream": "^2.0.2"
+            }
         },
         "string-length": {
             "version": "2.0.0",
@@ -4507,6 +9164,18 @@
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
+        "strip-indent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+            "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
         "supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -4514,6 +9183,24 @@
             "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
+            }
+        },
+        "supports-hyperlinks": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+            "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^2.0.0",
+                "supports-color": "^5.0.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "dev": true
+                }
             }
         },
         "symbol": {
@@ -4615,11 +9302,33 @@
                 }
             }
         },
+        "text-extensions": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+            "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+            "dev": true
+        },
         "throat": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
             "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
             "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
         },
         "tmpl": {
             "version": "1.0.4",
@@ -4693,6 +9402,24 @@
             "requires": {
                 "punycode": "^2.1.0"
             }
+        },
+        "traverse": {
+            "version": "0.6.6",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+            "dev": true
+        },
+        "trim-newlines": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+            "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+            "dev": true
+        },
+        "trim-off-newlines": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+            "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+            "dev": true
         },
         "trim-right": {
             "version": "1.0.1",
@@ -4896,6 +9623,21 @@
                 }
             }
         },
+        "universal-user-agent": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz",
+            "integrity": "sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==",
+            "dev": true,
+            "requires": {
+                "os-name": "^3.0.0"
+            }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
+        },
         "unset-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -4949,6 +9691,18 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
             "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
+        },
+        "url-join": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
+            "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
+            "dev": true
+        },
+        "url-template": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+            "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
             "dev": true
         },
         "use": {
@@ -5065,6 +9819,15 @@
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
         },
+        "windows-release": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+            "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0"
+            }
+        },
         "wordwrap": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -5139,6 +9902,12 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
             "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
             "dev": true
         },
         "y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "axe-sarif-converter",
-    "version": "1.0.1",
+    "version": "0.0.0-managed-by-semantic-release",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "lodash": "^4.17.11",
         "prettier": "^1.16.4",
         "rimraf": "^2.6.3",
+        "semantic-release": "^15.13.3",
         "ts-jest": "^24.0.1",
         "tslint": "^5.15.0",
         "tslint-microsoft-contrib": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "axe-sarif-converter",
-    "version": "1.0.1",
+    "version": "0.0.0-managed-by-semantic-release",
     "description": "Convert axe-core accessibility scan results to the SARIF format",
     "main": "dist/index.js",
     "types": "dist/index.d.js",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,11 @@
         "lint": "tslint -p .",
         "format": "prettier --config prettier.config.js --write \"**/*\"",
         "format-check": "prettier --config prettier.config.js --check \"**/*\"",
-        "prepack": "npm run format-check && npm run lint && npm run build && npm run copyrightheaders",
+        "copyrightheaders": "license-check-and-add",
+        "precheckin": "npm run format-check && npm run lint && npm run build && npm test && npm run copyrightheaders",
         "watch:build": "tsc -p . --watch",
         "watch:test": "jest --watch --coverage false --colors",
-        "copyrightheaders": "license-check-and-add"
+        "semantic-release": "semantic-release"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
#### Description of changes

*(note: this PR sets up semantic-release with `--dry-run`, so we can double check what it thinks it would do in the real build/release environment. There will be a second separate PR removing --dry-run)*

Sets up [semantic-release](https://github.com/semantic-release/semantic-release) in its default configuration, which will run the following steps on every merge into master (after all the normal CI checks have passed only):

* Look for the most recent "vX.Y.Z" tag in the repo
* Look at all the merge commits to master since that point
* If any contain `fix:` or `feat:` work, start a new release
* Parse the commit messages as [Conventional Commits](https://www.conventionalcommits.org) to form release notes
* Use `fix:`/`feat:`/`BREAKING CHANGE:` info in the merge commits to determine the next [semantic version](https://semver.org)
* Bump the version in package.json/package-lock.json
* Create a new GitHub release (via @ada-cat), which includes pushing a new git tag for the new version
* run npm publish to publish the new version

Note that the build step running semantic-release is conditionalized to only run on the master branch, and only in Pipelines that explicitly specify an opt-in variable. We will be using this to cause the publishing step to occur only from the secondary CI build I've set up with publishing credentials via @ada-cat and [accessibility-insights-team](https://www.npmjs.com/~accessibility-insights-team).

#### Pull request checklist

- [x] Addresses an existing issue: Implements user story #1492605
- [x] **n/a** Added relevant unit test for your changes. (`npm run test`)
- [x] **n/a** Verified code coverage for the changes made.
