### PR TITLE
chore: add test-results to license check exclusion list

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,13 +68,14 @@
         "license": "copyright-header.txt",
         "exact_paths_method": "EXCLUDE",
         "exact_paths": [
-            "./dist",
-            "./.vscode",
             "./.git",
             "./.github",
-            "./node_modules",
+            "./.vscode",
             "./copyright-header.txt",
-            "./src/test-resources/"
+            "./dist",
+            "./node_modules",
+            "./src/test-resources/",
+            "./test-results"
         ],
         "file_type_method": "INCLUDE",
         "file_types": [


### PR DESCRIPTION
#### Description of changes

Excludes the test-results folder from the licence check. This used to slip under the radar, but the recent addition of npm test in npm precheckin means that npm precheckin now fails spuriously without this change.

I also alphabetized the list while I was here.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] **n/a** Addresses issue: #0000
- [x] **n/a** Added relevant unit tests for your changes. (`npm test`)
- [x] **n/a** Verified code coverage for the changes made.
