### PR TITLE
chore: propagate secret env vars to semantic release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,4 +74,7 @@ jobs:
                 command: custom
                 customCommand: run semantic-release
             displayName: npm run semantic-release (master branch only)
+            env:
+              GH_TOKEN: $(GH_TOKEN)
+              NPM_TOKEN: $(NPM_TOKEN)
             condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['EnableSemanticRelease'], 'true'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,6 +75,6 @@ jobs:
                 customCommand: run semantic-release
             displayName: npm run semantic-release (master branch only)
             env:
-              GH_TOKEN: $(GH_TOKEN)
-              NPM_TOKEN: $(NPM_TOKEN)
+                GH_TOKEN: $(GH_TOKEN)
+                NPM_TOKEN: $(NPM_TOKEN)
             condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['EnableSemanticRelease'], 'true'))


### PR DESCRIPTION
#### Description of changes

Per [Pipelines docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables), secret pipeline variables are not automatically propagated to env variables like non-secret variables are. This explicitly forwards the secret variables that semantic-release needs as environment variables.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] **n/a** (if applicable) Addresses issue: #0000
- [x] **n/a** Added relevant unit tests for your changes. (`npm test`)
- [x] **n/a** Verified code coverage for the changes made.
