### PR TITLE
chore: update casing for microsoft in code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners for everything in the repository.
-*   @Microsoft/accessibility-insights-web-code-owners
+*   @microsoft/accessibility-insights-web-code-owners


### PR DESCRIPTION
#### Description of changes

Updated casing from "Microsoft" to "microsoft" to match the updated casing of the microsoft github org.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [ ] (if applicable) Addresses issue: #0000 **N/A**
- [ ] Added relevant unit tests for your changes **N/A**
- [ ] Ran `yarn precheckin` **N/A**
- [ ] Verified code coverage for the changes made **N/A**
