### PR TITLE
fix: update README example to avoid using experimental fs.promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Before using axe-sarif-converter, you will need to run an [axe](https://github.c
 axe-sarif-converter exports a single function, named `convertAxeToSarif`. Use it like this:
 
 ```ts
+import * as Axe from 'axe';
+import * as AxePuppeteer from 'axe-puppeteer';
+import * as fs from 'fs';
+import * as Puppeteer from 'puppeteer'
+import * as util from 'util';
+
 import { convertAxeToSarif, SarifLog } from 'axe-sarif-converter';
 
 test('my accessibility test', async () => {
@@ -33,7 +39,7 @@ test('my accessibility test', async () => {
     const sarifResults: SarifLog = convertAxeToSarif(axeResults);
 
     // Output a SARIF file, perhaps for use with a Sarif Viewer tool
-    await fs.promises.writeFile(
+    await util.promisify(fs.writeFile)(
         './test-results/my-accessibility-test.sarif',
         JSON.stringify(sarifResults),
         { encoding: 'utf8' });


### PR DESCRIPTION
#### Description of changes

If you use the README's usage sample as-is in Node LTS, you'll get a warning about use of an experimental node API. This change updates the example to avoid the warning.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Addresses issue: #0000
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
