### PR TITLE
refactor: exported guid constant from wcag-taxonomy-provider

### DIFF
--- a/src/axe-tool-property-provider-21.test.ts
+++ b/src/axe-tool-property-provider-21.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { getAxeToolProperties21 } from './axe-tool-property-provider-21';
+import { WcagGuid } from './constants';
 import * as Sarif from './sarif/sarif-2.1.2';
 
 describe('axe-tool-property-provider 2.1', () => {
@@ -26,7 +27,7 @@ describe('axe-tool-property-provider 2.1', () => {
                         {
                             name: 'WCAG',
                             index: 0,
-                            guid: '',
+                            guid: WcagGuid,
                         },
                     ],
                 },

--- a/src/axe-tool-property-provider-21.test.ts
+++ b/src/axe-tool-property-provider-21.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { getAxeToolProperties21 } from './axe-tool-property-provider-21';
-import { WcagGuid } from './constants';
 import * as Sarif from './sarif/sarif-2.1.2';
+import { WcagGuid } from './wcag-taxonomy-provider';
 
 describe('axe-tool-property-provider 2.1', () => {
     describe('getAxeToolProperties21', () => {

--- a/src/axe-tool-property-provider-21.ts
+++ b/src/axe-tool-property-provider-21.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { WcagGuid } from './constants';
 import * as Sarif from './sarif/sarif-2.1.2';
 
 export function getAxeToolProperties21(): Sarif.Run['tool'] {
@@ -22,7 +23,7 @@ export function getAxeToolProperties21(): Sarif.Run['tool'] {
                 {
                     name: 'WCAG',
                     index: 0,
-                    guid: '',
+                    guid: WcagGuid,
                 },
             ],
         },

--- a/src/axe-tool-property-provider-21.ts
+++ b/src/axe-tool-property-provider-21.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { WcagGuid } from './constants';
 import * as Sarif from './sarif/sarif-2.1.2';
+import { WcagGuid } from './wcag-taxonomy-provider';
 
 export function getAxeToolProperties21(): Sarif.Run['tool'] {
     return {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const WcagGuid = 'ca34e0e1-5faf-4f55-a989-cdae42a98f18';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-export const WcagGuid = 'ca34e0e1-5faf-4f55-a989-cdae42a98f18';

--- a/src/wcag-taxonomy-provider.test.ts
+++ b/src/wcag-taxonomy-provider.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { WcagGuid } from './constants';
 import { DictionaryStringTo } from './dictionary-types';
 import * as Sarif from './sarif/sarif-2.1.2';
 import { WCAGLinkData } from './wcag-link-data';
@@ -15,7 +16,7 @@ describe('WCAGTaxonomyProvider', () => {
             organization: 'W3C',
             informationUri: 'https://www.w3.org/TR/WCAG21',
             version: '2.1',
-            guid: 'ca34e0e1-5faf-4f55-a989-cdae42a98f18',
+            guid: WcagGuid,
             isComprehensive: true,
             taxa: [],
         };

--- a/src/wcag-taxonomy-provider.test.ts
+++ b/src/wcag-taxonomy-provider.test.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { WcagGuid } from './constants';
 import { DictionaryStringTo } from './dictionary-types';
 import * as Sarif from './sarif/sarif-2.1.2';
 import { WCAGLinkData } from './wcag-link-data';
-import { getWcagTaxonomy } from './wcag-taxonomy-provider';
+import { getWcagTaxonomy, WcagGuid } from './wcag-taxonomy-provider';
 
 describe('WCAGTaxonomyProvider', () => {
     it('creates a Sarif.ToolComponent object with WCAG property information', () => {

--- a/src/wcag-taxonomy-provider.ts
+++ b/src/wcag-taxonomy-provider.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { WcagGuid } from './constants';
 import { DictionaryStringTo } from './dictionary-types';
 import * as Sarif from './sarif/sarif-2.1.2';
 import { WCAGLinkData } from './wcag-link-data';
@@ -14,7 +15,7 @@ export function getWcagTaxonomy(
         organization: 'W3C',
         informationUri: 'https://www.w3.org/TR/WCAG21',
         version: '2.1',
-        guid: 'ca34e0e1-5faf-4f55-a989-cdae42a98f18',
+        guid: WcagGuid,
         isComprehensive: true,
         taxa: getAllTaxaFromWcagLinkData(sortedWcagTags, tagsToWcagLinkData),
     };

--- a/src/wcag-taxonomy-provider.ts
+++ b/src/wcag-taxonomy-provider.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { WcagGuid } from './constants';
 import { DictionaryStringTo } from './dictionary-types';
 import * as Sarif from './sarif/sarif-2.1.2';
 import { WCAGLinkData } from './wcag-link-data';
 
+export const WcagGuid = 'ca34e0e1-5faf-4f55-a989-cdae42a98f18';
 export function getWcagTaxonomy(
     sortedWcagTags: string[],
     tagsToWcagLinkData: DictionaryStringTo<WCAGLinkData>,


### PR DESCRIPTION
#### Description of changes

- Moved GUID to exported constant in `wcag-taxonomy-provider.ts`
- Updated `axe-tool-property-provider` and `wcag-taxonomy-provider` files and tests to use GUID from `wcag-taxonomy-provider.ts`

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Partially implements WI: 1515731
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
