### PR TITLE
process rules from results for axe tool properties

### DIFF
--- a/src/axe-tool-property-provider-21.test.ts
+++ b/src/axe-tool-property-provider-21.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as Sarif from 'sarif';
 import { getAxeToolProperties21 } from './axe-tool-property-provider-21';
-import { WcagGuid } from './wcag-taxonomy-provider';
+import { getWcagTaxonomyReference } from './wcag-taxonomy-provider';
 
 describe('axe-tool-property-provider 2.1', () => {
     describe('getAxeToolProperties21', () => {
@@ -21,13 +21,7 @@ describe('axe-tool-property-provider 2.1', () => {
                 properties: {
                     'microsoft/qualityDomain': 'Accessibility',
                 },
-                supportedTaxonomies: [
-                    {
-                        name: 'WCAG',
-                        index: 0,
-                        guid: WcagGuid,
-                    },
-                ],
+                supportedTaxonomies: [getWcagTaxonomyReference()],
             };
 
             const actualResults: Sarif.ToolComponent = getAxeToolProperties21();

--- a/src/axe-tool-property-provider-21.test.ts
+++ b/src/axe-tool-property-provider-21.test.ts
@@ -6,34 +6,31 @@ import { WcagGuid } from './wcag-taxonomy-provider';
 
 describe('axe-tool-property-provider 2.1', () => {
     describe('getAxeToolProperties21', () => {
-        it("returns the axe properties as a Sarif.Run['tool']", () => {
-            const expectedResults: Sarif.Run['tool'] = {
-                driver: {
-                    name: 'axe-core',
-                    fullName: 'axe for Web v3.2.2',
-                    shortDescription: {
-                        text:
-                            'An open source accessibility rules library for automated testing.',
-                    },
-                    version: '3.2.2',
-                    semanticVersion: '3.2.2',
-                    informationUri: 'https://www.deque.com/axe/axe-for-web/',
-                    downloadUri:
-                        'https://www.npmjs.com/package/axe-core/v/3.2.2',
-                    properties: {
-                        'microsoft/qualityDomain': 'Accessibility',
-                    },
-                    supportedTaxonomies: [
-                        {
-                            name: 'WCAG',
-                            index: 0,
-                            guid: WcagGuid,
-                        },
-                    ],
+        it('returns the axe properties as a Sarif.ToolComponent', () => {
+            const expectedResults: Sarif.ToolComponent = {
+                name: 'axe-core',
+                fullName: 'axe for Web v3.2.2',
+                shortDescription: {
+                    text:
+                        'An open source accessibility rules library for automated testing.',
                 },
+                version: '3.2.2',
+                semanticVersion: '3.2.2',
+                informationUri: 'https://www.deque.com/axe/axe-for-web/',
+                downloadUri: 'https://www.npmjs.com/package/axe-core/v/3.2.2',
+                properties: {
+                    'microsoft/qualityDomain': 'Accessibility',
+                },
+                supportedTaxonomies: [
+                    {
+                        name: 'WCAG',
+                        index: 0,
+                        guid: WcagGuid,
+                    },
+                ],
             };
 
-            const actualResults: Sarif.Run['tool'] = getAxeToolProperties21();
+            const actualResults: Sarif.ToolComponent = getAxeToolProperties21();
             expect(actualResults).toEqual(expectedResults);
         });
     });

--- a/src/axe-tool-property-provider-21.ts
+++ b/src/axe-tool-property-provider-21.ts
@@ -3,29 +3,29 @@
 import * as Sarif from 'sarif';
 import { WcagGuid } from './wcag-taxonomy-provider';
 
-export function getAxeToolProperties21(): Sarif.Run['tool'] {
+export function getAxeToolProperties21(): Sarif.ToolComponent {
     return {
-        driver: {
-            name: 'axe-core',
-            fullName: 'axe for Web v3.2.2',
-            shortDescription: {
-                text:
-                    'An open source accessibility rules library for automated testing.',
-            },
-            version: '3.2.2',
-            semanticVersion: '3.2.2',
-            informationUri: 'https://www.deque.com/axe/axe-for-web/',
-            downloadUri: 'https://www.npmjs.com/package/axe-core/v/3.2.2',
-            properties: {
-                'microsoft/qualityDomain': 'Accessibility',
-            },
-            supportedTaxonomies: [
-                {
-                    name: 'WCAG',
-                    index: 0,
-                    guid: WcagGuid,
-                },
-            ],
+        name: 'axe-core',
+        fullName: 'axe for Web v3.2.2',
+        shortDescription: {
+            text:
+                'An open source accessibility rules library for automated testing.',
         },
+        version: '3.2.2',
+        semanticVersion: '3.2.2',
+        informationUri: 'https://www.deque.com/axe/axe-for-web/',
+        downloadUri: 'https://www.npmjs.com/package/axe-core/v/3.2.2',
+        properties: {
+            'microsoft/qualityDomain': 'Accessibility',
+        },
+        supportedTaxonomies: [getAxeToolSupportedTaxonomy()],
+    };
+}
+
+export function getAxeToolSupportedTaxonomy(): Sarif.ToolComponentReference {
+    return {
+        name: 'WCAG',
+        index: 0,
+        guid: WcagGuid,
     };
 }

--- a/src/axe-tool-property-provider-21.ts
+++ b/src/axe-tool-property-provider-21.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Sarif from 'sarif';
-import { WcagGuid } from './wcag-taxonomy-provider';
+import { getWcagTaxonomyReference } from './wcag-taxonomy-provider';
 
 export function getAxeToolProperties21(): Sarif.ToolComponent {
     return {
@@ -18,14 +18,6 @@ export function getAxeToolProperties21(): Sarif.ToolComponent {
         properties: {
             'microsoft/qualityDomain': 'Accessibility',
         },
-        supportedTaxonomies: [getAxeToolSupportedTaxonomy()],
-    };
-}
-
-export function getAxeToolSupportedTaxonomy(): Sarif.ToolComponentReference {
-    return {
-        name: 'WCAG',
-        index: 0,
-        guid: WcagGuid,
+        supportedTaxonomies: [getWcagTaxonomyReference()],
     };
 }

--- a/src/result-to-rule-converter.test.ts
+++ b/src/result-to-rule-converter.test.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 import { TagValue } from 'axe-core';
 import * as Sarif from 'sarif';
-import { getAxeToolSupportedTaxonomy } from './axe-tool-property-provider-21';
 import {
     DecoratedAxeResult,
     DecoratedAxeResults,
 } from './decorated-axe-results';
 import { DictionaryStringTo } from './dictionary-types';
 import { ResultToRuleConverter } from './result-to-rule-converter';
+import { getWcagTaxonomyReference } from './wcag-taxonomy-provider';
 
 describe('ResultToRuleConverter', () => {
     let resultToRuleConverter: ResultToRuleConverter;
@@ -77,7 +77,7 @@ describe('ResultToRuleConverter', () => {
                             target: {
                                 id: 'stub_tag_1',
                                 index: 0,
-                                toolComponent: getAxeToolSupportedTaxonomy(),
+                                toolComponent: getWcagTaxonomyReference(),
                             },
                             kinds: ['superset'],
                         },
@@ -85,7 +85,7 @@ describe('ResultToRuleConverter', () => {
                             target: {
                                 id: 'stub_tag_3',
                                 index: 14,
-                                toolComponent: getAxeToolSupportedTaxonomy(),
+                                toolComponent: getWcagTaxonomyReference(),
                             },
                             kinds: ['superset'],
                         },

--- a/src/result-to-rule-converter.test.ts
+++ b/src/result-to-rule-converter.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TagValue } from 'axe-core';
+import * as Sarif from 'sarif';
+import { getAxeToolSupportedTaxonomy } from './axe-tool-property-provider-21';
+import {
+    DecoratedAxeResult,
+    DecoratedAxeResults,
+} from './decorated-axe-results';
+import { DictionaryStringTo } from './dictionary-types';
+import { ResultToRuleConverter } from './result-to-rule-converter';
+
+describe('ResultToRuleConverter', () => {
+    let resultToRuleConverter: ResultToRuleConverter;
+    beforeAll(() => {
+        const stub_results: DecoratedAxeResults = {
+            passes: [] as DecoratedAxeResult[],
+            violations: [
+                {
+                    id: 'stub_id',
+                    tags: ([
+                        'stub_tag_1',
+                        'stub_tag_3',
+                        'a_tag',
+                    ] as unknown) as TagValue[],
+                    description: 'stub_description',
+                    help: 'stub_help_info',
+                    helpUrl: 'stub_url',
+                },
+                {
+                    id: 'stub_id_2',
+                    tags: (['tag_2'] as unknown) as TagValue[],
+                    description: 'stub_description_2',
+                    help: 'stub_help_info_2',
+                    helpUrl: 'stub_url_2',
+                },
+                // repeating the same rule id to test that rules are added only once
+                {
+                    id: 'stub_id_2',
+                    tags: (['tag_2'] as unknown) as TagValue[],
+                    description: 'stub_description_2',
+                    help: 'stub_help_info_2',
+                    helpUrl: 'stub_url_2',
+                },
+            ] as DecoratedAxeResult[],
+            inapplicable: [] as DecoratedAxeResult[],
+            incomplete: [] as DecoratedAxeResult[],
+            timestamp: 'stub_timestamp',
+            targetPageUrl: 'stub_url',
+            targetPageTitle: 'stub_title',
+        };
+        const stub_tags = ['stub_tag_1', 'stub_tag_2', 'stub_tag_3'];
+        const stub_tags_to_indices = {
+            stub_tag_1: 0,
+            stub_tag_2: 20,
+            stub_tag_3: 14,
+        };
+        resultToRuleConverter = new ResultToRuleConverter(
+            stub_results,
+            stub_tags,
+            stub_tags_to_indices,
+        );
+    });
+
+    describe('getRulePropertiesFromResults', () => {
+        it('returns array of unique axe rules as Sarif.ReportingDescriptor[] from axe results', () => {
+            const expectedResults: Sarif.ReportingDescriptor[] = [
+                {
+                    id: 'stub_id',
+                    name: 'stub_help_info',
+                    fullDescription: {
+                        text: 'stub_description',
+                    },
+                    helpUri: 'stub_url',
+                    relationships: [
+                        {
+                            target: {
+                                id: 'stub_tag_1',
+                                index: 0,
+                                toolComponent: getAxeToolSupportedTaxonomy(),
+                            },
+                            kinds: ['superset'],
+                        },
+                        {
+                            target: {
+                                id: 'stub_tag_3',
+                                index: 14,
+                                toolComponent: getAxeToolSupportedTaxonomy(),
+                            },
+                            kinds: ['superset'],
+                        },
+                    ],
+                },
+                {
+                    id: 'stub_id_2',
+                    name: 'stub_help_info_2',
+                    fullDescription: {
+                        text: 'stub_description_2',
+                    },
+                    helpUri: 'stub_url_2',
+                    relationships: [],
+                },
+            ];
+            const actualResults: Sarif.ReportingDescriptor[] = resultToRuleConverter.getRulePropertiesFromResults();
+
+            expect(actualResults).toEqual(expectedResults);
+        });
+    });
+
+    describe('getRuleIdsToRuleIndices', () => {
+        it('returns a dictionary of rule ids to their indices in a sorted array of rule ids', () => {
+            const expectedResults: DictionaryStringTo<number> = {
+                stub_id: 0,
+                stub_id_2: 1,
+            };
+
+            const actualResults: DictionaryStringTo<
+                number
+            > = resultToRuleConverter.getRuleIdsToRuleIndices();
+
+            expect(actualResults).toEqual(expectedResults);
+        });
+    });
+});

--- a/src/result-to-rule-converter.ts
+++ b/src/result-to-rule-converter.ts
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as Sarif from 'sarif';
+import { getAxeToolSupportedTaxonomy } from './axe-tool-property-provider-21';
+import {
+    DecoratedAxeResult,
+    DecoratedAxeResults,
+} from './decorated-axe-results';
+import { DictionaryStringTo } from './dictionary-types';
+
+export class ResultToRuleConverter {
+    private readonly ruleIdsToRuleIndices: DictionaryStringTo<number> = {};
+
+    public getRulePropertiesFromResults(
+        results: DecoratedAxeResults,
+        axeTags: string[],
+        wcagTagsToTaxaIndices: DictionaryStringTo<number>,
+    ): Sarif.ReportingDescriptor[] {
+        const rulesDictionary: DictionaryStringTo<
+            Sarif.ReportingDescriptor
+        > = this.convertResultsToRules(results, axeTags, wcagTagsToTaxaIndices);
+        const sortedRuleIds: string[] = this.sortRuleIds(rulesDictionary);
+        this.indexRuleIds(sortedRuleIds);
+        return sortedRuleIds.map(ruleId => rulesDictionary[ruleId]);
+    }
+
+    public getRuleIdsToRuleIndices(): DictionaryStringTo<number> {
+        return this.ruleIdsToRuleIndices;
+    }
+
+    private sortRuleIds(
+        rulesDictionary: DictionaryStringTo<Sarif.ReportingDescriptor>,
+    ): string[] {
+        return Object.keys(rulesDictionary).sort();
+    }
+
+    private indexRuleIds(sortedIds: string[]) {
+        for (let i = 0; i < sortedIds.length; i++) {
+            this.ruleIdsToRuleIndices[sortedIds[i]] = i;
+        }
+    }
+
+    private convertResultsToRules(
+        results: DecoratedAxeResults,
+        axeTags: string[],
+        wcagTagsToTaxaIndices: DictionaryStringTo<number>,
+    ): DictionaryStringTo<Sarif.ReportingDescriptor> {
+        const rulesDictionary: DictionaryStringTo<
+            Sarif.ReportingDescriptor
+        > = {};
+
+        this.convertRuleResultsToRules(
+            rulesDictionary,
+            axeTags,
+            wcagTagsToTaxaIndices,
+            results.violations,
+        );
+        this.convertRuleResultsToRules(
+            rulesDictionary,
+            axeTags,
+            wcagTagsToTaxaIndices,
+            results.passes,
+        );
+        this.convertRuleResultsToRules(
+            rulesDictionary,
+            axeTags,
+            wcagTagsToTaxaIndices,
+            results.inapplicable,
+        );
+        this.convertRuleResultsToRules(
+            rulesDictionary,
+            axeTags,
+            wcagTagsToTaxaIndices,
+            results.incomplete,
+        );
+
+        return rulesDictionary;
+    }
+
+    private convertRuleResultsToRules(
+        rulesDictionary: DictionaryStringTo<Sarif.ReportingDescriptor>,
+        axeTags: string[],
+        wcagTagsToTaxaIndices: DictionaryStringTo<number>,
+        ruleResults: DecoratedAxeResult[],
+    ): void {
+        if (ruleResults) {
+            for (const ruleResult of ruleResults) {
+                this.convertRuleResultToRule(
+                    rulesDictionary,
+                    axeTags,
+                    wcagTagsToTaxaIndices,
+                    ruleResult,
+                );
+            }
+        }
+    }
+
+    private convertRuleResultToRule(
+        rulesDictionary: DictionaryStringTo<Sarif.ReportingDescriptor>,
+        axeTags: string[],
+        wcagTagsToTaxaIndices: DictionaryStringTo<number>,
+        ruleResult: DecoratedAxeResult,
+    ): void {
+        if (!rulesDictionary.hasOwnProperty(ruleResult.id)) {
+            const rule: Sarif.ReportingDescriptor = {
+                id: ruleResult.id,
+                name: ruleResult.help,
+                fullDescription: {
+                    text: ruleResult.description,
+                },
+                helpUri: ruleResult.helpUrl,
+                relationships: this.getRelationshipsFromResultTags(
+                    axeTags,
+                    wcagTagsToTaxaIndices,
+                    ruleResult,
+                ),
+            };
+            rulesDictionary[ruleResult.id] = rule;
+        }
+    }
+
+    private getRelationshipsFromResultTags(
+        axeTags: string[],
+        wcagTagsToTaxaIndices: DictionaryStringTo<number>,
+        result: DecoratedAxeResult,
+    ) {
+        return result.tags
+            .filter(tag => axeTags.indexOf(tag) != -1)
+            .map(tag => {
+                return {
+                    target: {
+                        id: tag,
+                        index: wcagTagsToTaxaIndices[tag],
+                        toolComponent: getAxeToolSupportedTaxonomy(),
+                    },
+                    kinds: ['superset'],
+                };
+            });
+    }
+}

--- a/src/result-to-rule-converter.ts
+++ b/src/result-to-rule-converter.ts
@@ -10,33 +10,36 @@ import { DictionaryStringTo } from './dictionary-types';
 
 export class ResultToRuleConverter {
     private readonly ruleIdsToRuleIndices: DictionaryStringTo<number> = {};
+    private readonly rulesDictionary: DictionaryStringTo<
+        Sarif.ReportingDescriptor
+    > = {};
+    private sortedRuleIds: string[] = [];
 
-    public getRulePropertiesFromResults(
+    constructor(
         results: DecoratedAxeResults,
         axeTags: string[],
         wcagTagsToTaxaIndices: DictionaryStringTo<number>,
-    ): Sarif.ReportingDescriptor[] {
-        const rulesDictionary: DictionaryStringTo<
-            Sarif.ReportingDescriptor
-        > = this.convertResultsToRules(results, axeTags, wcagTagsToTaxaIndices);
-        const sortedRuleIds: string[] = this.sortRuleIds(rulesDictionary);
-        this.indexRuleIds(sortedRuleIds);
-        return sortedRuleIds.map(ruleId => rulesDictionary[ruleId]);
+    ) {
+        this.convertResultsToRules(results, axeTags, wcagTagsToTaxaIndices);
+        this.sortRuleIds();
+        this.indexRuleIds();
+    }
+
+    public getRulePropertiesFromResults(): Sarif.ReportingDescriptor[] {
+        return this.sortedRuleIds.map(ruleId => this.rulesDictionary[ruleId]);
     }
 
     public getRuleIdsToRuleIndices(): DictionaryStringTo<number> {
         return this.ruleIdsToRuleIndices;
     }
 
-    private sortRuleIds(
-        rulesDictionary: DictionaryStringTo<Sarif.ReportingDescriptor>,
-    ): string[] {
-        return Object.keys(rulesDictionary).sort();
+    private sortRuleIds(): void {
+        this.sortedRuleIds = Object.keys(this.rulesDictionary).sort();
     }
 
-    private indexRuleIds(sortedIds: string[]) {
-        for (let i = 0; i < sortedIds.length; i++) {
-            this.ruleIdsToRuleIndices[sortedIds[i]] = i;
+    private indexRuleIds() {
+        for (let i = 0; i < this.sortedRuleIds.length; i++) {
+            this.ruleIdsToRuleIndices[this.sortedRuleIds[i]] = i;
         }
     }
 
@@ -44,41 +47,30 @@ export class ResultToRuleConverter {
         results: DecoratedAxeResults,
         axeTags: string[],
         wcagTagsToTaxaIndices: DictionaryStringTo<number>,
-    ): DictionaryStringTo<Sarif.ReportingDescriptor> {
-        const rulesDictionary: DictionaryStringTo<
-            Sarif.ReportingDescriptor
-        > = {};
-
+    ): void {
         this.convertRuleResultsToRules(
-            rulesDictionary,
             axeTags,
             wcagTagsToTaxaIndices,
             results.violations,
         );
         this.convertRuleResultsToRules(
-            rulesDictionary,
             axeTags,
             wcagTagsToTaxaIndices,
             results.passes,
         );
         this.convertRuleResultsToRules(
-            rulesDictionary,
             axeTags,
             wcagTagsToTaxaIndices,
             results.inapplicable,
         );
         this.convertRuleResultsToRules(
-            rulesDictionary,
             axeTags,
             wcagTagsToTaxaIndices,
             results.incomplete,
         );
-
-        return rulesDictionary;
     }
 
     private convertRuleResultsToRules(
-        rulesDictionary: DictionaryStringTo<Sarif.ReportingDescriptor>,
         axeTags: string[],
         wcagTagsToTaxaIndices: DictionaryStringTo<number>,
         ruleResults: DecoratedAxeResult[],
@@ -86,7 +78,6 @@ export class ResultToRuleConverter {
         if (ruleResults) {
             for (const ruleResult of ruleResults) {
                 this.convertRuleResultToRule(
-                    rulesDictionary,
                     axeTags,
                     wcagTagsToTaxaIndices,
                     ruleResult,
@@ -96,12 +87,11 @@ export class ResultToRuleConverter {
     }
 
     private convertRuleResultToRule(
-        rulesDictionary: DictionaryStringTo<Sarif.ReportingDescriptor>,
         axeTags: string[],
         wcagTagsToTaxaIndices: DictionaryStringTo<number>,
         ruleResult: DecoratedAxeResult,
     ): void {
-        if (!rulesDictionary.hasOwnProperty(ruleResult.id)) {
+        if (!this.rulesDictionary.hasOwnProperty(ruleResult.id)) {
             const rule: Sarif.ReportingDescriptor = {
                 id: ruleResult.id,
                 name: ruleResult.help,
@@ -115,7 +105,7 @@ export class ResultToRuleConverter {
                     ruleResult,
                 ),
             };
-            rulesDictionary[ruleResult.id] = rule;
+            this.rulesDictionary[ruleResult.id] = rule;
         }
     }
 

--- a/src/result-to-rule-converter.ts
+++ b/src/result-to-rule-converter.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Sarif from 'sarif';
-import { getAxeToolSupportedTaxonomy } from './axe-tool-property-provider-21';
 import {
     DecoratedAxeResult,
     DecoratedAxeResults,
 } from './decorated-axe-results';
 import { DictionaryStringTo } from './dictionary-types';
+import { getWcagTaxonomyReference } from './wcag-taxonomy-provider';
 
 export class ResultToRuleConverter {
     private readonly ruleIdsToRuleIndices: DictionaryStringTo<number> = {};
@@ -121,7 +121,7 @@ export class ResultToRuleConverter {
                     target: {
                         id: tag,
                         index: wcagTagsToTaxaIndices[tag],
-                        toolComponent: getAxeToolSupportedTaxonomy(),
+                        toolComponent: getWcagTaxonomyReference(),
                     },
                     kinds: ['superset'],
                 };

--- a/src/sarif-converter-21.test.ts
+++ b/src/sarif-converter-21.test.ts
@@ -23,6 +23,7 @@ describe('SarifConverter21', () => {
         const stubToolProperties: Sarif.Run['tool'] = {
             driver: {
                 name: 'stub_tool_property',
+                rules: [],
             },
         };
         const stubInvocations: Sarif.Invocation[] = [
@@ -43,8 +44,8 @@ describe('SarifConverter21', () => {
         const converterPropertyProviderStub: () => Sarif.Run['conversion'] = () => {
             return {} as Sarif.Run['conversion'];
         };
-        const axeToolPropertyProviderStub: () => Sarif.Run['tool'] = () => {
-            return {} as Sarif.Run['tool'];
+        const axeToolPropertyProviderStub: () => Sarif.ToolComponent = () => {
+            return {} as Sarif.ToolComponent;
         };
         const invocationProviderStub: () => Sarif.Invocation[] = () => {
             return stubInvocations;
@@ -55,11 +56,11 @@ describe('SarifConverter21', () => {
 
         it('outputs a sarif log whose run uses the axeToolPropertyProvider to populate the tool property', () => {
             const axeToolPropertyProviderMock: IMock<
-                () => Sarif.Run['tool']
+                () => Sarif.ToolComponent
             > = Mock.ofInstance(getAxeToolProperties21);
             axeToolPropertyProviderMock
                 .setup(ap => ap())
-                .returns(() => stubToolProperties)
+                .returns(() => stubToolProperties['driver'])
                 .verifiable(Times.once());
 
             const irrelevantResults: DecoratedAxeResults = {} as DecoratedAxeResults;

--- a/src/sarif-converter-21.ts
+++ b/src/sarif-converter-21.ts
@@ -37,8 +37,6 @@ export class SarifConverter21 {
         this.tagsToWcagLinkData,
     );
 
-    private ruleIdsToRuleIndices: DictionaryStringTo<number> = {};
-
     public constructor(
         private getConverterToolProperties: () => Sarif.Run['conversion'],
         private getAxeProperties: () => Sarif.ToolComponent,
@@ -72,12 +70,18 @@ export class SarifConverter21 {
             };
         }
 
+        const resultToRuleConverter: ResultToRuleConverter = new ResultToRuleConverter(
+            results,
+            this.wcagLinkDataIndexer.getSortedWcagTags(),
+            this.wcagLinkDataIndexer.getWcagTagsToTaxaIndices(),
+        );
+
         const run: Sarif.Run = {
             conversion: this.getConverterToolProperties(),
             tool: {
                 driver: {
                     ...this.getAxeProperties(),
-                    rules: this.convertResultsToRules(results),
+                    rules: resultToRuleConverter.getRulePropertiesFromResults(),
                 },
             },
             invocations: this.invocationConverter(
@@ -106,16 +110,6 @@ export class SarifConverter21 {
         }
 
         return run;
-    }
-
-    private convertResultsToRules(results: DecoratedAxeResults) {
-        const resultToRuleConverter: ResultToRuleConverter = new ResultToRuleConverter(
-            results,
-            this.wcagLinkDataIndexer.getSortedWcagTags(),
-            this.wcagLinkDataIndexer.getWcagTagsToTaxaIndices(),
-        );
-        this.ruleIdsToRuleIndices = resultToRuleConverter.getRuleIdsToRuleIndices();
-        return resultToRuleConverter.getRulePropertiesFromResults();
     }
 
     private convertResults(

--- a/src/sarif-converter-21.ts
+++ b/src/sarif-converter-21.ts
@@ -109,15 +109,13 @@ export class SarifConverter21 {
     }
 
     private convertResultsToRules(results: DecoratedAxeResults) {
-        const resultToRuleConverter: ResultToRuleConverter = new ResultToRuleConverter();
-        const rules = resultToRuleConverter.getRulePropertiesFromResults(
+        const resultToRuleConverter: ResultToRuleConverter = new ResultToRuleConverter(
             results,
             this.wcagLinkDataIndexer.getSortedWcagTags(),
             this.wcagLinkDataIndexer.getWcagTagsToTaxaIndices(),
         );
         this.ruleIdsToRuleIndices = resultToRuleConverter.getRuleIdsToRuleIndices();
-
-        return rules;
+        return resultToRuleConverter.getRulePropertiesFromResults();
     }
 
     private convertResults(

--- a/src/wcag-taxonomy-provider.test.ts
+++ b/src/wcag-taxonomy-provider.test.ts
@@ -3,100 +3,120 @@
 import * as Sarif from 'sarif';
 import { DictionaryStringTo } from './dictionary-types';
 import { WCAGLinkData } from './wcag-link-data';
-import { getWcagTaxonomy, WcagGuid } from './wcag-taxonomy-provider';
+import {
+    getWcagTaxonomy,
+    getWcagTaxonomyReference,
+    WcagGuid,
+} from './wcag-taxonomy-provider';
 
 describe('WCAGTaxonomyProvider', () => {
-    it('creates a Sarif.ToolComponent object with WCAG property information', () => {
-        const sortedTagsStub: string[] = [];
-        const tagsToWcagLinkDataStub: DictionaryStringTo<WCAGLinkData> = {};
-        const expectedResultsStub: Sarif.ToolComponent = {
-            name: 'WCAG',
-            fullName: 'Web Content Accessibility Guidelines (WCAG) 2.1',
-            organization: 'W3C',
-            informationUri: 'https://www.w3.org/TR/WCAG21',
-            version: '2.1',
-            guid: WcagGuid,
-            isComprehensive: true,
-            taxa: [],
-        };
-        const actualResults: Sarif.ToolComponent = getWcagTaxonomy(
-            sortedTagsStub,
-            tagsToWcagLinkDataStub,
-        );
+    describe('getWcagTaxonomyReference', () => {
+        it('returns a Sarif.ToolComponentReference with WCAG taxonomy reference properties', () => {
+            const expectedResults: Sarif.ToolComponentReference = {
+                name: 'WCAG',
+                index: 0,
+                guid: WcagGuid,
+            };
 
-        expect(actualResults).toEqual(expectedResultsStub);
+            const actualResults: Sarif.ToolComponentReference = getWcagTaxonomyReference();
+
+            expect(actualResults).toEqual(expectedResults);
+        });
     });
 
-    it('creates a Sarif.ToolComponent object with taxa properties based on given tagsToWcagLinkData', () => {
-        const sortedTagsStub: string[] = ['stub_id_1', 'stub_id_2'];
-        const tagsToWcagLinkDataStub: DictionaryStringTo<WCAGLinkData> = {
-            stub_id_1: createWcagLinkDataObject(
-                'stub_name_1',
-                'stub_url_1',
-                'stub_title_1',
-            ),
-            stub_id_2: createWcagLinkDataObject(
-                'stub_name_2',
-                'stub_url_2',
-                'stub_title_2',
-            ),
-        };
-        const expectedResults = [
-            {
-                id: 'stub_id_1',
-                name: 'stub_name_1',
-                shortDescription: {
-                    text: 'stub_title_1',
+    describe('getWcagTaxonomy', () => {
+        it('creates a Sarif.ToolComponent object with WCAG property information', () => {
+            const sortedTagsStub: string[] = [];
+            const tagsToWcagLinkDataStub: DictionaryStringTo<WCAGLinkData> = {};
+            const expectedResultsStub: Sarif.ToolComponent = {
+                name: 'WCAG',
+                fullName: 'Web Content Accessibility Guidelines (WCAG) 2.1',
+                organization: 'W3C',
+                informationUri: 'https://www.w3.org/TR/WCAG21',
+                version: '2.1',
+                guid: WcagGuid,
+                isComprehensive: true,
+                taxa: [],
+            };
+            const actualResults: Sarif.ToolComponent = getWcagTaxonomy(
+                sortedTagsStub,
+                tagsToWcagLinkDataStub,
+            );
+
+            expect(actualResults).toEqual(expectedResultsStub);
+        });
+
+        it('creates a Sarif.ToolComponent object with taxa properties based on given tagsToWcagLinkData', () => {
+            const sortedTagsStub: string[] = ['stub_id_1', 'stub_id_2'];
+            const tagsToWcagLinkDataStub: DictionaryStringTo<WCAGLinkData> = {
+                stub_id_1: createWcagLinkDataObject(
+                    'stub_name_1',
+                    'stub_url_1',
+                    'stub_title_1',
+                ),
+                stub_id_2: createWcagLinkDataObject(
+                    'stub_name_2',
+                    'stub_url_2',
+                    'stub_title_2',
+                ),
+            };
+            const expectedResults = [
+                {
+                    id: 'stub_id_1',
+                    name: 'stub_name_1',
+                    shortDescription: {
+                        text: 'stub_title_1',
+                    },
+                    helpUri: 'stub_url_1',
                 },
-                helpUri: 'stub_url_1',
-            },
-            {
-                id: 'stub_id_2',
-                name: 'stub_name_2',
-                shortDescription: {
-                    text: 'stub_title_2',
+                {
+                    id: 'stub_id_2',
+                    name: 'stub_name_2',
+                    shortDescription: {
+                        text: 'stub_title_2',
+                    },
+                    helpUri: 'stub_url_2',
                 },
-                helpUri: 'stub_url_2',
-            },
-        ];
+            ];
 
-        const actualResults: Sarif.ToolComponent = getWcagTaxonomy(
-            sortedTagsStub,
-            tagsToWcagLinkDataStub,
-        );
+            const actualResults: Sarif.ToolComponent = getWcagTaxonomy(
+                sortedTagsStub,
+                tagsToWcagLinkDataStub,
+            );
 
-        expect(actualResults).toHaveProperty('taxa', expectedResults);
+            expect(actualResults).toHaveProperty('taxa', expectedResults);
+        });
+
+        it('creates a Sarif.Tool Component object with taxa properties where WCAGLinkData title and url are empty', () => {
+            const sortedTagsStub: string[] = ['stub_id'];
+            const tagsToWcagLinkDataStub: DictionaryStringTo<WCAGLinkData> = {
+                stub_id: { text: 'stub_name' },
+            };
+            const expectedResults = [
+                {
+                    id: 'stub_id',
+                    name: 'stub_name',
+                },
+            ];
+
+            const actualResults: Sarif.ToolComponent = getWcagTaxonomy(
+                sortedTagsStub,
+                tagsToWcagLinkDataStub,
+            );
+
+            expect(actualResults).toHaveProperty('taxa', expectedResults);
+        });
+
+        function createWcagLinkDataObject(
+            text: string,
+            url: string,
+            title: string,
+        ) {
+            return {
+                text: text,
+                title: title,
+                url: url,
+            };
+        }
     });
-
-    it('creates a Sarif.Tool Component object with taxa properties where WCAGLinkData title and url are empty', () => {
-        const sortedTagsStub: string[] = ['stub_id'];
-        const tagsToWcagLinkDataStub: DictionaryStringTo<WCAGLinkData> = {
-            stub_id: { text: 'stub_name' },
-        };
-        const expectedResults = [
-            {
-                id: 'stub_id',
-                name: 'stub_name',
-            },
-        ];
-
-        const actualResults: Sarif.ToolComponent = getWcagTaxonomy(
-            sortedTagsStub,
-            tagsToWcagLinkDataStub,
-        );
-
-        expect(actualResults).toHaveProperty('taxa', expectedResults);
-    });
-
-    function createWcagLinkDataObject(
-        text: string,
-        url: string,
-        title: string,
-    ) {
-        return {
-            text: text,
-            title: title,
-            url: url,
-        };
-    }
 });

--- a/src/wcag-taxonomy-provider.ts
+++ b/src/wcag-taxonomy-provider.ts
@@ -5,6 +5,15 @@ import { DictionaryStringTo } from './dictionary-types';
 import { WCAGLinkData } from './wcag-link-data';
 
 export const WcagGuid = 'ca34e0e1-5faf-4f55-a989-cdae42a98f18';
+
+export function getWcagTaxonomyReference(): Sarif.ToolComponentReference {
+    return {
+        name: 'WCAG',
+        index: 0,
+        guid: WcagGuid,
+    };
+}
+
 export function getWcagTaxonomy(
     sortedWcagTags: string[],
     tagsToWcagLinkData: DictionaryStringTo<WCAGLinkData>,


### PR DESCRIPTION
#### Description of changes

- Moved `driver` property from axe-tool-property-provider to `sarif-converter-21` so it's easier to add rules to axe tool property
- Moved functions for converting results to rules from `sarif-converter-21` to new class `ResultToRuleConverter` (will remove `ResultDecorator` in future PR)
- Added function to format rules in `rulesDictionary` to relationships
- Added unit tests for `ResultToRuleConverter`
- Added rules to axe tool properties in `sarif-converter-21`
- Moved WCAG taxonomy reference data and getter to `wcag-taxonomy-provider` and added relevant unit test

#### Pull request checklist

- [ ] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes) **N/A this is part of a feature**
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Implements: 1553642
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
