### PR TITLE
convert axe results to sarif results

### DIFF
--- a/src/artifact-property-provider.test.ts
+++ b/src/artifact-property-provider.test.ts
@@ -24,9 +24,6 @@ describe('artifact-property-provider', () => {
                 },
                 sourceLanguage: 'html',
                 roles: ['analysisTarget'],
-                description: {
-                    text: targetPageTitle,
-                },
             };
 
             const actualResults: Sarif.Artifact = getArtifactProperties(

--- a/src/artifact-property-provider.ts
+++ b/src/artifact-property-provider.ts
@@ -7,14 +7,20 @@ export function getArtifactProperties(
     environmentData: EnvironmentData,
 ): Sarif.Artifact {
     return {
-        location: {
-            uri: environmentData.targetPageUrl,
-            index: 0,
-        },
+        location: getArtifactLocation(environmentData),
         sourceLanguage: 'html',
         roles: ['analysisTarget'],
         description: {
             text: environmentData.targetPageTitle,
         },
+    };
+}
+
+export function getArtifactLocation(
+    environmentData: EnvironmentData,
+): Sarif.Artifact['location'] {
+    return {
+        uri: environmentData.targetPageUrl,
+        index: 0,
     };
 }

--- a/src/artifact-property-provider.ts
+++ b/src/artifact-property-provider.ts
@@ -10,9 +10,6 @@ export function getArtifactProperties(
         location: getArtifactLocation(environmentData),
         sourceLanguage: 'html',
         roles: ['analysisTarget'],
-        description: {
-            text: environmentData.targetPageTitle,
-        },
     };
 }
 

--- a/src/result-to-rule-converter.test.ts
+++ b/src/result-to-rule-converter.test.ts
@@ -69,7 +69,7 @@ describe('ResultToRuleConverter', () => {
                     id: 'stub_id',
                     name: 'stub_help_info',
                     fullDescription: {
-                        text: 'stub_description',
+                        text: 'stub_description.',
                     },
                     helpUri: 'stub_url',
                     relationships: [
@@ -95,7 +95,7 @@ describe('ResultToRuleConverter', () => {
                     id: 'stub_id_2',
                     name: 'stub_help_info_2',
                     fullDescription: {
-                        text: 'stub_description_2',
+                        text: 'stub_description_2.',
                     },
                     helpUri: 'stub_url_2',
                     relationships: [],

--- a/src/result-to-rule-converter.ts
+++ b/src/result-to-rule-converter.ts
@@ -96,7 +96,7 @@ export class ResultToRuleConverter {
                 id: ruleResult.id,
                 name: ruleResult.help,
                 fullDescription: {
-                    text: ruleResult.description,
+                    text: ruleResult.description + '.',
                 },
                 helpUri: ruleResult.helpUrl,
                 relationships: this.getRelationshipsFromResultTags(

--- a/src/sarif-converter-21.ts
+++ b/src/sarif-converter-21.ts
@@ -195,7 +195,7 @@ export class SarifConverter21 {
 
     private getLogicalLocations(node: Axe.NodeResult): Sarif.LogicalLocation[] {
         const selector: string = node.target.join(';');
-        let logicalLocations: Sarif.LogicalLocation[] = [
+        const logicalLocations: Sarif.LogicalLocation[] = [
             this.formatLogicalLocation(selector),
         ];
         // casting node as "any" works around axe-core/#1636
@@ -297,7 +297,7 @@ export class SarifConverter21 {
                     kind: kind,
                     level: this.getResultLevelFromResultKind(kind),
                     message: {
-                        text: '',
+                        text: ruleResult.description,
                     },
                 });
             }

--- a/src/sarif-converter-21.ts
+++ b/src/sarif-converter-21.ts
@@ -214,16 +214,15 @@ export class SarifConverter21 {
 
     private getLogicalLocations(node: Axe.NodeResult): Sarif.LogicalLocation[] {
         const selector: string = node.target.join(';');
-        // let logicalLocations: Sarif.LogicalLocation[] = [
-        return [this.formatLogicalLocation(selector)];
-        // if(node.xpath) {
-        //     let nodeXpath: string = node.xpath.join(';');
-        //     logicalLocations.push({
-        //         fullyQualifiedName: nodeXpath,
-        //         kind: 'element'
-        //     })
-        // }
-        // return logicalLocations;
+        let logicalLocations: Sarif.LogicalLocation[] = [
+            this.formatLogicalLocation(selector),
+        ];
+        // casting node as "any" works around axe-core/#1636
+        if ((node as any).xpath) {
+            let nodeXpath: string = (node as any).xpath.join(';');
+            logicalLocations.push(this.formatLogicalLocation(nodeXpath));
+        }
+        return logicalLocations;
     }
 
     private formatLogicalLocation(name: string): Sarif.LogicalLocation {

--- a/src/sarif-converter-21.ts
+++ b/src/sarif-converter-21.ts
@@ -18,7 +18,6 @@ import { EnvironmentData } from './environment-data';
 import { getEnvironmentDataFromResults } from './environment-data-provider';
 import { getInvocations21 } from './invocation-provider-21';
 import { ResultToRuleConverter } from './result-to-rule-converter';
-import * as CustomSarif from './sarif/custom-sarif-types-21';
 import { isNotEmpty } from './string-utils';
 import { axeTagsToWcagLinkData, WCAGLinkData } from './wcag-link-data';
 import { WCAGLinkDataIndexer } from './wcag-link-data-indexer';
@@ -56,7 +55,7 @@ export class SarifConverter21 {
         options: ConverterOptions,
     ): Sarif.Log {
         return {
-            version: CustomSarif.SarifLogVersion21.version,
+            version: '2.1.0',
             runs: [this.convertRun(results, options)],
         };
     }
@@ -113,28 +112,28 @@ export class SarifConverter21 {
             resultArray,
             results.violations,
             ruleIdsToRuleIndices,
-            CustomSarif.Result.kind.fail,
+            'fail',
             environmentData,
         );
         this.convertRuleResults(
             resultArray,
             results.passes,
             ruleIdsToRuleIndices,
-            CustomSarif.Result.kind.pass,
+            'pass',
             environmentData,
         );
         this.convertRuleResults(
             resultArray,
             results.incomplete,
             ruleIdsToRuleIndices,
-            CustomSarif.Result.kind.open,
+            'open',
             environmentData,
         );
         this.convertRuleResultsWithoutNodes(
             resultArray,
             results.inapplicable,
             ruleIdsToRuleIndices,
-            CustomSarif.Result.kind.notApplicable,
+            'notApplicable',
         );
 
         return resultArray;
@@ -144,7 +143,7 @@ export class SarifConverter21 {
         resultArray: Sarif.Result[],
         ruleResults: DecoratedAxeResult[],
         ruleIdsToRuleIndices: DictionaryStringTo<number>,
-        kind: CustomSarif.Result.kind,
+        kind: Sarif.Result.kind,
         environmentData: EnvironmentData,
     ): void {
         if (ruleResults) {
@@ -164,7 +163,7 @@ export class SarifConverter21 {
         resultArray: Sarif.Result[],
         ruleResult: DecoratedAxeResult,
         ruleIdsToRuleIndices: DictionaryStringTo<number>,
-        kind: CustomSarif.Result.kind,
+        kind: Sarif.Result.kind,
         environmentData: EnvironmentData,
     ): void {
         for (const node of ruleResult.nodes) {
@@ -215,12 +214,12 @@ export class SarifConverter21 {
 
     private convertMessage(
         node: Axe.NodeResult,
-        kind: CustomSarif.Result.kind,
+        kind: Sarif.Result.kind,
     ): Sarif.Message {
         const textArray: string[] = [];
         const markdownArray: string[] = [];
 
-        if (kind === CustomSarif.Result.kind.fail) {
+        if (kind === 'fail') {
             const allAndNone = node.all.concat(node.none);
             this.convertMessageChecks(
                 'Fix all of the following:',
@@ -287,7 +286,7 @@ export class SarifConverter21 {
         resultArray: Sarif.Result[],
         ruleResults: DecoratedAxeResult[],
         ruleIdsToRuleIndices: DictionaryStringTo<number>,
-        kind: CustomSarif.Result.kind,
+        kind: Sarif.Result.kind,
     ): void {
         if (ruleResults) {
             for (const ruleResult of ruleResults) {
@@ -304,9 +303,7 @@ export class SarifConverter21 {
         }
     }
 
-    private getResultLevelFromResultKind(kind: CustomSarif.Result.kind) {
-        return kind === CustomSarif.Result.kind.fail
-            ? CustomSarif.Result.level.error
-            : CustomSarif.Result.level.none;
+    private getResultLevelFromResultKind(kind: Sarif.Result.kind) {
+        return kind === 'fail' ? 'error' : 'none';
     }
 }

--- a/src/sarif-converter-21.ts
+++ b/src/sarif-converter-21.ts
@@ -95,7 +95,11 @@ export class SarifConverter21 {
                     getEnvironmentDataFromResults(results),
                 ),
             ],
-            results: this.convertResults(results, properties),
+            results: this.convertResults(
+                results,
+                properties,
+                resultToRuleConverter.getRuleIdsToRuleIndices(),
+            ),
             taxonomies: [
                 getWcagTaxonomy(
                     this.wcagLinkDataIndexer.getSortedWcagTags(),
@@ -118,6 +122,7 @@ export class SarifConverter21 {
     private convertResults(
         results: DecoratedAxeResults,
         properties: DictionaryStringTo<string>,
+        ruleIdsToRuleIndices: DictionaryStringTo<number>,
     ): Sarif.Result[] {
         const resultArray: Sarif.Result[] = [];
         const environmentData: EnvironmentData = getEnvironmentDataFromResults(
@@ -127,18 +132,21 @@ export class SarifConverter21 {
         this.convertRuleResults(
             resultArray,
             results.violations,
+            ruleIdsToRuleIndices,
             CustomSarif.Result.level.error,
             environmentData,
         );
         this.convertRuleResults(
             resultArray,
             results.passes,
+            ruleIdsToRuleIndices,
             CustomSarif.Result.level.pass,
             environmentData,
         );
         this.convertRuleResults(
             resultArray,
             results.incomplete,
+            ruleIdsToRuleIndices,
             CustomSarif.Result.level.open,
             environmentData,
         );
@@ -155,6 +163,7 @@ export class SarifConverter21 {
     private convertRuleResults(
         resultArray: Sarif.Result[],
         ruleResults: DecoratedAxeResult[],
+        ruleIdsToRuleIndices: DictionaryStringTo<number>,
         level: CustomSarif.Result.level,
         environmentData: EnvironmentData,
     ): void {
@@ -163,6 +172,7 @@ export class SarifConverter21 {
                 this.convertRuleResult(
                     resultArray,
                     ruleResult,
+                    ruleIdsToRuleIndices,
                     level,
                     environmentData,
                 );
@@ -173,13 +183,14 @@ export class SarifConverter21 {
     private convertRuleResult(
         resultArray: Sarif.Result[],
         ruleResult: DecoratedAxeResult,
+        ruleIdsToRuleIndices: DictionaryStringTo<number>,
         level: CustomSarif.Result.level,
         environmentData: EnvironmentData,
     ): void {
         for (const node of ruleResult.nodes) {
             resultArray.push({
                 ruleId: ruleResult.id,
-                ruleIndex: this.ruleIdsToRuleIndices[ruleResult.id],
+                ruleIndex: ruleIdsToRuleIndices[ruleResult.id],
                 // level: level,
                 message: this.convertMessage(node, level),
                 locations: [

--- a/src/sarif-converter-21.ts
+++ b/src/sarif-converter-21.ts
@@ -65,21 +65,13 @@ export class SarifConverter21 {
         results: DecoratedAxeResults,
         options: ConverterOptions,
     ): Sarif.Run {
-        let properties: DictionaryStringTo<string> = {};
-
-        if (options && options.scanName !== undefined) {
-            properties = {
-                scanName: options.scanName,
-            };
-        }
-
         const resultToRuleConverter: ResultToRuleConverter = new ResultToRuleConverter(
             results,
             this.wcagLinkDataIndexer.getSortedWcagTags(),
             this.wcagLinkDataIndexer.getWcagTagsToTaxaIndices(),
         );
 
-        const run: Sarif.Run = {
+        return {
             conversion: this.getConverterToolProperties(),
             tool: {
                 driver: {
@@ -97,7 +89,6 @@ export class SarifConverter21 {
             ],
             results: this.convertResults(
                 results,
-                properties,
                 resultToRuleConverter.getRuleIdsToRuleIndices(),
             ),
             taxonomies: [
@@ -107,21 +98,10 @@ export class SarifConverter21 {
                 ),
             ],
         };
-
-        if (options && options.testCaseId !== undefined) {
-            run.properties!.testCaseId = options.testCaseId;
-        }
-
-        if (options && options.scanId !== undefined) {
-            // run.logicalId = options.scanId;
-        }
-
-        return run;
     }
 
     private convertResults(
         results: DecoratedAxeResults,
-        properties: DictionaryStringTo<string>,
         ruleIdsToRuleIndices: DictionaryStringTo<number>,
     ): Sarif.Result[] {
         const resultArray: Sarif.Result[] = [];

--- a/src/sarif-converter-21.ts
+++ b/src/sarif-converter-21.ts
@@ -286,10 +286,10 @@ export class SarifConverter21 {
     ): void {
         if (checkResults.length > 0) {
             const textLines: string[] = [];
-            const richTextLines: string[] = [];
+            const markdownLines: string[] = [];
 
             textLines.push(heading);
-            richTextLines.push(this.escapeForMarkdown(heading));
+            markdownLines.push(this.escapeForMarkdown(heading));
 
             for (const checkResult of checkResults) {
                 const message = isNotEmpty(checkResult.message)
@@ -297,11 +297,13 @@ export class SarifConverter21 {
                     : checkResult.id;
 
                 textLines.push(message + '.');
-                richTextLines.push('- ' + this.escapeForMarkdown(message));
+                markdownLines.push(
+                    '- ' + this.escapeForMarkdown(message) + '.',
+                );
             }
 
             textArray.push(textLines.join(' '));
-            markdownArray.push(richTextLines.join('\n'));
+            markdownArray.push(markdownLines.join('\n'));
         }
     }
 

--- a/src/sarif-converter-21.ts
+++ b/src/sarif-converter-21.ts
@@ -153,8 +153,8 @@ export class SarifConverter21 {
         this.convertRuleResultsWithoutNodes(
             resultArray,
             results.inapplicable,
+            ruleIdsToRuleIndices,
             CustomSarif.Result.level.notApplicable,
-            properties,
         );
 
         return resultArray;
@@ -232,14 +232,6 @@ export class SarifConverter21 {
         };
     }
 
-    private getPartialFingerprintsFromRule(
-        ruleResult: DecoratedAxeResult,
-    ): DictionaryStringTo<string> {
-        return {
-            ruleId: ruleResult.id,
-        };
-    }
-
     private convertMessage(
         node: Axe.NodeResult,
         level: CustomSarif.Result.level,
@@ -313,23 +305,19 @@ export class SarifConverter21 {
     private convertRuleResultsWithoutNodes(
         resultArray: Sarif.Result[],
         ruleResults: DecoratedAxeResult[],
+        ruleIdsToRuleIndices: DictionaryStringTo<number>,
         level: CustomSarif.Result.level,
-        properties: DictionaryStringTo<string>,
     ): void {
         if (ruleResults) {
             for (const ruleResult of ruleResults) {
-                const partialFingerprints = this.getPartialFingerprintsFromRule(
-                    ruleResult,
-                );
-                // resultArray.push({
-                // ruleId: ruleResult.id,
-                // level: level,
-                // properties: {
-                // ...properties,
-                // tags: ['Accessibility'],
-                // },
-                // partialFingerprints: partialFingerprints,
-                // });
+                resultArray.push({
+                    ruleId: ruleResult.id,
+                    ruleIndex: ruleIdsToRuleIndices[ruleResult.id],
+                    // level: level,
+                    message: {
+                        text: '',
+                    },
+                });
             }
         }
     }

--- a/src/sarif/custom-sarif-types-21.ts
+++ b/src/sarif/custom-sarif-types-21.ts
@@ -21,33 +21,3 @@ export namespace Result {
         error = 'error',
     }
 }
-
-/**
- * Encapsulates a message intended to be read by the end user.
- */
-export interface Message {
-    /**
-     * A plain text message string.
-     */
-    text?: string;
-
-    /**
-     * The resource id for a plain text message string.
-     */
-    messageId?: string;
-
-    /**
-     * A rich text message string.
-     */
-    richText?: string;
-
-    /**
-     * The resource id for a rich text message string.
-     */
-    richMessageId?: string;
-
-    /**
-     * An array of strings to substitute into the message string.
-     */
-    arguments?: string[];
-}

--- a/src/sarif/custom-sarif-types-21.ts
+++ b/src/sarif/custom-sarif-types-21.ts
@@ -5,13 +5,20 @@ export const enum SarifLogVersion21 {
 }
 
 export namespace Result {
-    export const enum level {
+    export const enum kind {
         notApplicable = 'notApplicable',
         pass = 'pass',
+        fail = 'fail',
+        review = 'review',
+        open = 'open',
+        informational = 'informational',
+    }
+
+    export const enum level {
+        none = 'none',
         note = 'note',
         warning = 'warning',
         error = 'error',
-        open = 'open',
     }
 }
 

--- a/src/test-resources/basic-axe-v3.2.2-reporter-v2.json
+++ b/src/test-resources/basic-axe-v3.2.2-reporter-v2.json
@@ -15,7 +15,6 @@
     },
     "timestamp": "2019-03-22T19:12:06.129Z",
     "url": "https://www.washington.edu/accesscomputing/AU/before.html",
-    "targetPageTitle": "Accessible University Demo Site - Inaccessible Version",
     "toolOptions": {
         "reporter": "v2"
     },

--- a/src/test-resources/basic-axe-v3.2.2-reporter-v2.json
+++ b/src/test-resources/basic-axe-v3.2.2-reporter-v2.json
@@ -14,7 +14,7 @@
         "orientationType": "landscape-primary"
     },
     "timestamp": "2019-03-22T19:12:06.129Z",
-    "targetPageUrl": "https://www.washington.edu/accesscomputing/AU/before.html",
+    "url": "https://www.washington.edu/accesscomputing/AU/before.html",
     "targetPageTitle": "Accessible University Demo Site - Inaccessible Version",
     "toolOptions": {
         "reporter": "v2"

--- a/src/test-resources/basic-axe-v3.2.2-sarif-v2.1.2.sarif
+++ b/src/test-resources/basic-axe-v3.2.2-sarif-v2.1.2.sarif
@@ -86,6 +86,7 @@
           {
             "ruleId": "document-title",
             "ruleIndex": 0,
+            "kind": "fail",
             "level": "error",
             "message": {
               "text": "Fix any of the following: Document does not have a non-empty <title> element.",

--- a/src/test-resources/basic-axe-v3.2.2-sarif-v2.1.2.sarif
+++ b/src/test-resources/basic-axe-v3.2.2-sarif-v2.1.2.sarif
@@ -79,10 +79,7 @@
             "sourceLanguage": "html",
             "roles": [
               "analysisTarget"
-            ],
-            "description": {
-              "text": "Accessible University Demo Site - Inaccessible Version"
-            }
+            ]
           }
         ],
         "results": [
@@ -92,7 +89,7 @@
             "level": "error",
             "message": {
               "text": "Fix any of the following: Document does not have a non-empty <title> element.",
-              "markdown": "Fix any of the following:\n  Document does not have a non-empty <title> element."
+              "markdown": "Fix any of the following:\n- Document does not have a non-empty &lt;title> element."
             },
             "locations": [
               {


### PR DESCRIPTION
#### Description of changes

- Modified `sarif-converter-21.ts` to output axe results to sarif v2.1.2 results
- Removed `description` property from `artifact-property-provider.ts` and `basic-axe-v3.2.2-sarif-v2.1.2.sarif` because target page title is unspecified in axe results
- Changed `targetPageUrl` to `url` in `basic-axe-v3.2.2-reporter-v2.json` because `targetPageUrl` is used only in `DecoratedAxeResults`
- Removed unused `partialFingerprints` and `properties` from `sarif-converter-21.ts`
- Updated `custom-sarif-types-21.ts` Result `kind` and `level` enums to match Sarif types and removed custom `Message` type
- Removed references to `custom-sarif-types-21.ts` in `sarif-converter-21.ts` (will remove `custom-sarif-types-21.ts` completely after `axe-raw-sarif-converter` support for sarif v2.1.2 is done)
- Additional minor updates to `basic-axe-v3.2.2-sarif-v2.1.2.sarif`: added `kind` property to Sarif.Run and periods in various places to fix Sarif.Multitool check errors

#### Pull request checklist

- [ ] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Implements WI: 1553644
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
