### PR TITLE
chore: copied axe-raw-sarif-converter to axe-raw-sarif-converter-21

### DIFF
--- a/src/axe-raw-sarif-converter-21.test.ts
+++ b/src/axe-raw-sarif-converter-21.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AxeResults } from 'axe-core';
+import * as fs from 'fs';
+import { sortBy } from 'lodash';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { convertAxeToSarif } from '.';
+import { AxeRawResult } from './axe-raw-result';
+import {
+    AxeRawSarifConverter,
+    defaultAxeRawSarifConverter,
+} from './axe-raw-sarif-converter';
+import { getAxeToolProperties } from './axe-tool-property-provider';
+import { ConverterOptions } from './converter-options';
+import { EnvironmentData } from './environment-data';
+import { getInvocations } from './invocation-provider';
+import * as Sarif from './sarif/sarif-2.0.0';
+import { SarifLog } from './sarif/sarif-log';
+
+function normalizeSarif(sarif: SarifLog): void {
+    sarif.runs[0].results = sortBy(sarif.runs[0].results, [
+        'ruleId',
+        'partialFingerprints.fullyQualifiedLogicalName',
+        'level',
+    ]);
+    sarif.runs[0].resources!.rules = sortBy(sarif.runs[0].resources!.rules, [
+        'id',
+    ]) as any;
+}
+
+describe('AxeRawSarifConverter', () => {
+    describe('integrated with default dependencies', () => {
+        let testSubject: AxeRawSarifConverter;
+
+        beforeEach(() => {
+            testSubject = defaultAxeRawSarifConverter();
+        });
+
+        it('produces the same output as the v2 converter for equivalent raw input', () => {
+            const axeJSON: string = fs.readFileSync(
+                './src/test-resources/axe-v3.2.2.reporter-v2.json',
+                'utf8',
+            );
+            const axeResult: AxeResults = JSON.parse(axeJSON) as AxeResults;
+            const axeToSarifOutput = convertAxeToSarif(axeResult);
+
+            const axeRawJSON: string = fs.readFileSync(
+                './src/test-resources/axe-v3.2.2.reporter-raw.json',
+                'utf8',
+            );
+            const axeRawResult: AxeRawResult[] = JSON.parse(
+                axeRawJSON,
+            ) as AxeRawResult[];
+
+            const environmentDataStub: EnvironmentData = {
+                timestamp: axeResult.timestamp,
+                targetPageUrl: axeResult.url,
+                targetPageTitle: '',
+            };
+
+            const axeRawToSarifOutput = testSubject.convert(
+                axeRawResult,
+                {},
+                environmentDataStub,
+            );
+
+            normalizeSarif(axeRawToSarifOutput);
+            normalizeSarif(axeToSarifOutput);
+
+            expect(axeRawToSarifOutput).toEqual(axeToSarifOutput);
+        });
+    });
+
+    describe('convert', () => {
+        let stubEnvironmentData: EnvironmentData;
+
+        const stubToolProperties: Sarif.Run['tool'] = {
+            name: 'stub_tool_property',
+        };
+        const stubInvocations: Sarif.Invocation[] = [
+            { commandLine: 'stub_invocation' },
+        ];
+
+        const axeToolPropertyProviderStub: () => Sarif.Run['tool'] = () => {
+            return {} as Sarif.Run['tool'];
+        };
+        const invocationProviderStub: () => Sarif.Invocation[] = () => {
+            return stubInvocations;
+        };
+
+        beforeEach(() => {
+            stubEnvironmentData = {
+                targetPageUrl: 'stub_url',
+            } as EnvironmentData;
+        });
+
+        it('outputs a sarif log whose run uses the axeToolPropertyProvider to populate the tool property', () => {
+            const axeToolPropertyProviderMock: IMock<
+                () => Sarif.Run['tool']
+            > = Mock.ofInstance(getAxeToolProperties);
+            axeToolPropertyProviderMock
+                .setup(ap => ap())
+                .returns(() => stubToolProperties)
+                .verifiable(Times.once());
+
+            const testSubject = new AxeRawSarifConverter(
+                axeToolPropertyProviderMock.object,
+                invocationProviderStub,
+            );
+            const irrelevantResults: AxeRawResult[] = [];
+            const irrelevantOptions: ConverterOptions = {};
+
+            const actualResults = testSubject.convert(
+                irrelevantResults,
+                irrelevantOptions,
+                stubEnvironmentData,
+            );
+
+            axeToolPropertyProviderMock.verifyAll();
+            expect(actualResults).toHaveProperty('runs');
+            expect(actualResults.runs[0]).toHaveProperty(
+                'tool',
+                stubToolProperties,
+            );
+        });
+
+        it('outputs a sarif log whose run uses the invocationsProvider to populate the invocations property', () => {
+            const invocationProviderMock: IMock<
+                (environmentData: EnvironmentData) => Sarif.Invocation[]
+            > = Mock.ofInstance(getInvocations);
+            invocationProviderMock
+                .setup(ip =>
+                    ip(It.isObjectWith<EnvironmentData>(stubEnvironmentData)),
+                )
+                .returns(() => stubInvocations)
+                .verifiable(Times.once());
+
+            const testSubject = new AxeRawSarifConverter(
+                axeToolPropertyProviderStub,
+                invocationProviderMock.object,
+            );
+            const irrelevantResults: AxeRawResult[] = [];
+            const irrelevantOptions: ConverterOptions = {};
+
+            const actualResults = testSubject.convert(
+                irrelevantResults,
+                irrelevantOptions,
+                stubEnvironmentData,
+            );
+
+            invocationProviderMock.verifyAll();
+            expect(actualResults).toHaveProperty('runs');
+            expect(actualResults.runs[0]).toHaveProperty(
+                'invocations',
+                stubInvocations,
+            );
+        });
+    });
+});

--- a/src/axe-raw-sarif-converter-21.ts
+++ b/src/axe-raw-sarif-converter-21.ts
@@ -1,0 +1,343 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { isEmpty } from './array-utils';
+import {
+    AxeRawCheckResult,
+    AxeRawNodeResult,
+    AxeRawResult,
+    ResultValue,
+} from './axe-raw-result';
+import { getAxeToolProperties } from './axe-tool-property-provider';
+import { ConverterOptions } from './converter-options';
+import { DictionaryStringTo } from './dictionary-types';
+import { EnvironmentData } from './environment-data';
+import { getInvocations } from './invocation-provider';
+import * as CustomSarif from './sarif/custom-sarif-types';
+import * as Sarif from './sarif/sarif-2.0.0';
+import { SarifLog } from './sarif/sarif-log';
+import { escapeForMarkdown, isNotEmpty } from './string-utils';
+
+export function defaultAxeRawSarifConverter(): AxeRawSarifConverter {
+    return new AxeRawSarifConverter(getAxeToolProperties, getInvocations);
+}
+
+export class AxeRawSarifConverter {
+    public constructor(
+        private getAxeProperties: () => Sarif.Run['tool'],
+        private invocationConverter: (
+            environmentData: EnvironmentData,
+        ) => Sarif.Invocation[],
+    ) {}
+
+    public convert(
+        results: AxeRawResult[],
+        converterOptions: ConverterOptions,
+        environmentData: EnvironmentData,
+    ): SarifLog {
+        return {
+            version: CustomSarif.SarifLogVersion.v2,
+            runs: [this.convertRun(results, converterOptions, environmentData)],
+        };
+    }
+
+    private convertRun(
+        results: AxeRawResult[],
+        converterOptions: ConverterOptions,
+        environmentData: EnvironmentData,
+    ): Sarif.Run {
+        const run: Sarif.Run = {
+            tool: this.getAxeProperties(),
+            invocations: this.invocationConverter(environmentData),
+            files: this.getTargetPageProperties(environmentData),
+            results: this.convertRawResults(
+                results,
+                this.getExtraSarifResultProperties(converterOptions),
+                environmentData,
+            ),
+            resources: {
+                rules: this.convertResultsToRules(results),
+            },
+            properties: {},
+        };
+
+        this.fillInRunPropertiesFromOptions(run, converterOptions);
+
+        return run;
+    }
+
+    private getTargetPageProperties(
+        environmentData: EnvironmentData,
+    ): DictionaryStringTo<Sarif.File> {
+        const files: DictionaryStringTo<Sarif.File> = {};
+        files[environmentData.targetPageUrl] = {
+            mimeType: 'text/html',
+            properties: {
+                tags: ['target'],
+                title: environmentData.targetPageTitle,
+            },
+        };
+        return files;
+    }
+
+    private getExtraSarifResultProperties(
+        converterOptions: ConverterOptions,
+    ): DictionaryStringTo<string> {
+        let extraSarifResultProperties: DictionaryStringTo<string> = {};
+        if (converterOptions && converterOptions.scanName !== undefined) {
+            extraSarifResultProperties = {
+                scanName: converterOptions.scanName,
+            };
+        }
+        return extraSarifResultProperties;
+    }
+
+    private fillInRunPropertiesFromOptions(
+        run: Sarif.Run,
+        converterOptions: ConverterOptions,
+    ): void {
+        if (converterOptions.testCaseId !== undefined) {
+            run.properties!.testCaseId = converterOptions.testCaseId;
+        }
+
+        if (converterOptions.scanId !== undefined) {
+            run.logicalId = converterOptions.scanId;
+        }
+    }
+
+    private convertRawResults(
+        results: AxeRawResult[],
+        extraSarifResultProperties: DictionaryStringTo<string>,
+        environmentData: EnvironmentData,
+    ): Sarif.Result[] {
+        const resultArray: Sarif.Result[] = [];
+
+        for (const result of results) {
+            const axeRawNodeResultArrays = [
+                result.violations,
+                result.passes,
+                result.incomplete,
+                result.inapplicable,
+            ];
+
+            for (const axeRawNodeResultArray of axeRawNodeResultArrays) {
+                if (!axeRawNodeResultArray) {
+                    continue;
+                }
+                resultArray.push(
+                    ...this.convertRawNodeResults(
+                        axeRawNodeResultArray,
+                        extraSarifResultProperties,
+                        environmentData.targetPageUrl,
+                        result.id,
+                    ),
+                );
+            }
+            if (axeRawNodeResultArrays.every(isEmpty)) {
+                resultArray.push(
+                    this.generateResultForInapplicableRule(
+                        extraSarifResultProperties,
+                        result.id,
+                    ),
+                );
+            }
+        }
+
+        return resultArray;
+    }
+
+    private convertRawNodeResults(
+        rawNodeResults: AxeRawNodeResult[],
+        extraSarifResultProperties: DictionaryStringTo<string>,
+        targetPageUrl: string,
+        ruleId: string,
+    ): Sarif.Result[] {
+        if (rawNodeResults) {
+            return rawNodeResults.map(rawNodeResult =>
+                this.convertRawNodeResult(
+                    rawNodeResult,
+                    extraSarifResultProperties,
+                    targetPageUrl,
+                    ruleId,
+                ),
+            );
+        }
+        return [];
+    }
+
+    private convertRawNodeResult(
+        axeRawNodeResult: AxeRawNodeResult,
+        extraSarifResultProperties: DictionaryStringTo<string>,
+        targetPageUrl: string,
+        ruleId: string,
+    ): Sarif.Result {
+        const level = this.getSarifResultLevel(axeRawNodeResult.result);
+        const selector = this.getLogicalNameFromRawNode(axeRawNodeResult);
+        return {
+            ruleId: ruleId,
+            level: level,
+            message: this.convertMessage(axeRawNodeResult, level),
+            locations: [
+                {
+                    physicalLocation: {
+                        fileLocation: {
+                            uri: targetPageUrl,
+                        },
+                    },
+                    fullyQualifiedLogicalName: selector,
+                    annotations: [
+                        {
+                            snippet: {
+                                text: axeRawNodeResult.node.source,
+                            },
+                        },
+                    ],
+                },
+            ],
+            properties: {
+                ...extraSarifResultProperties,
+                tags: ['Accessibility'],
+            },
+            partialFingerprints: {
+                fullyQualifiedLogicalName: selector,
+                ruleId: ruleId,
+            },
+        };
+    }
+
+    private generateResultForInapplicableRule(
+        extraSarifResultProperties: DictionaryStringTo<string>,
+        ruleId: string,
+    ): Sarif.Result {
+        return {
+            ruleId: ruleId,
+            level: CustomSarif.Result.level.notApplicable,
+            properties: {
+                ...extraSarifResultProperties,
+                tags: ['Accessibility'],
+            },
+            partialFingerprints: {
+                ruleId: ruleId,
+            },
+        };
+    }
+
+    private getSarifResultLevel(
+        resultValue?: ResultValue,
+    ): CustomSarif.Result.level {
+        const resultToLevelMapping: {
+            [K in ResultValue]: CustomSarif.Result.level
+        } = {
+            passed: CustomSarif.Result.level.pass,
+            failed: CustomSarif.Result.level.error,
+            inapplicable: CustomSarif.Result.level.notApplicable,
+            cantTell: CustomSarif.Result.level.open,
+        };
+
+        if (!resultValue) {
+            throw new Error(
+                'getSarifResultLevel(resultValue): resultValue is undefined',
+            );
+        }
+
+        return resultToLevelMapping[resultValue];
+    }
+
+    private getLogicalNameFromRawNode(axeRawNodeResult: AxeRawNodeResult) {
+        if (!axeRawNodeResult.node.selector) {
+            throw new Error(
+                'getLogicalNameFromRawNode: axe result contained a node with no selector',
+            );
+        }
+        return axeRawNodeResult.node.selector.join(';');
+    }
+
+    private convertMessage(
+        node: AxeRawNodeResult,
+        level: CustomSarif.Result.level,
+    ): CustomSarif.Message {
+        const textArray: string[] = [];
+        const richTextArray: string[] = [];
+
+        if (level === CustomSarif.Result.level.error) {
+            const allAndNone = node.all.concat(node.none);
+            this.convertMessageChecks(
+                'Fix all of the following:',
+                allAndNone,
+                textArray,
+                richTextArray,
+            );
+            this.convertMessageChecks(
+                'Fix any of the following:',
+                node.any,
+                textArray,
+                richTextArray,
+            );
+        } else {
+            const allNodes = node.all.concat(node.none).concat(node.any);
+            this.convertMessageChecks(
+                'The following tests passed:',
+                allNodes,
+                textArray,
+                richTextArray,
+            );
+        }
+
+        return {
+            text: textArray.join(' '),
+            richText: richTextArray.join('\n\n'),
+        };
+    }
+
+    private convertMessageChecks(
+        heading: string,
+        checkResults: AxeRawCheckResult[],
+        textArray: string[],
+        richTextArray: string[],
+    ): void {
+        if (checkResults.length > 0) {
+            const textLines: string[] = [];
+            const richTextLines: string[] = [];
+
+            textLines.push(heading);
+            richTextLines.push(escapeForMarkdown(heading));
+
+            for (const checkResult of checkResults) {
+                const message = isNotEmpty(checkResult.message)
+                    ? checkResult.message
+                    : checkResult.id;
+
+                textLines.push(message + '.');
+                richTextLines.push('- ' + escapeForMarkdown(message));
+            }
+
+            textArray.push(textLines.join(' '));
+            richTextArray.push(richTextLines.join('\n'));
+        }
+    }
+
+    private convertResultsToRules(
+        results: AxeRawResult[],
+    ): DictionaryStringTo<Sarif.Rule> {
+        const rulesDictionary: DictionaryStringTo<Sarif.Rule> = {};
+
+        for (const result of results) {
+            rulesDictionary[result.id] = this.axeRawResultToSarifRule(result);
+        }
+
+        return rulesDictionary;
+    }
+
+    private axeRawResultToSarifRule(axeRawResult: AxeRawResult): Sarif.Rule {
+        return {
+            id: axeRawResult.id,
+            name: {
+                text: axeRawResult.help,
+            },
+            fullDescription: {
+                text: axeRawResult.description,
+            },
+            helpUri: axeRawResult.helpUrl,
+            properties: {},
+        };
+    }
+}


### PR DESCRIPTION
#### Description of changes

- Copied `axe-raw-sarif-converter.ts` and `axe-raw-sarif-converter.test.ts` to `axe-raw-sarif-converter-21.ts` and `axe-raw-sarif-converter-21.test.ts`, respectively, to make comparing changes for the updated axe raw to sarif v2.1.2 converter easier to see/review. The old axe-raw-sarif-converter files will be removed and these files will be renamed to exclude `-21` once implementation is complete.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Addresses issue: #0000 **N/A**
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
