### PR TITLE
chore: update axe raw sarif converter to output sarif v2.1.2 part 1

### DIFF
--- a/src/axe-raw-sarif-converter-21.test.ts
+++ b/src/axe-raw-sarif-converter-21.test.ts
@@ -1,16 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AxeResults } from 'axe-core';
+import * as fs from 'fs';
 import { sortBy } from 'lodash';
 import * as Sarif from 'sarif';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { getArtifactProperties } from './artifact-property-provider';
 import { AxeRawResult } from './axe-raw-result';
-import { AxeRawSarifConverter21 } from './axe-raw-sarif-converter-21';
+import {
+    AxeRawSarifConverter21,
+    defaultAxeRawSarifConverter21,
+} from './axe-raw-sarif-converter-21';
 import { getAxeToolProperties21 } from './axe-tool-property-provider-21';
 import { ConverterOptions } from './converter-options';
 import { getConverterProperties } from './converter-property-provider';
 import { EnvironmentData } from './environment-data';
 import { getInvocations21 } from './invocation-provider-21';
+import { defaultSarifConverter21 } from './sarif-converter-21';
 
 function normalizeSarif(sarif: Sarif.Log): void {
     sarif.runs[0].results = sortBy(sarif.runs[0].results, [
@@ -25,50 +31,50 @@ function normalizeSarif(sarif: Sarif.Log): void {
 }
 
 describe('AxeRawSarifConverter21', () => {
-    // describe('integrated with default dependencies', () => {
-    //     let testSubject: AxeRawSarifConverter21;
+    describe('integrated with default dependencies', () => {
+        let testSubject: AxeRawSarifConverter21;
 
-    //     beforeEach(() => {
-    //         testSubject = defaultAxeRawSarifConverter21();
-    //     });
+        beforeEach(() => {
+            testSubject = defaultAxeRawSarifConverter21();
+        });
 
-    //     it('produces the same output as the v2 converter for equivalent raw input', () => {
-    //         const axeJSON: string = fs.readFileSync(
-    //             './src/test-resources/axe-v3.2.2.reporter-v2.json',
-    //             'utf8',
-    //         );
-    //         const axeResult: AxeResults = JSON.parse(axeJSON) as AxeResults;
-    //         const axeToSarifOutput = defaultSarifConverter21().convert(
-    //             axeResult,
-    //             {},
-    //         );
+        it.skip('produces the same output as the v2 converter for equivalent raw input', () => {
+            const axeJSON: string = fs.readFileSync(
+                './src/test-resources/axe-v3.2.2.reporter-v2.json',
+                'utf8',
+            );
+            const axeResult: AxeResults = JSON.parse(axeJSON) as AxeResults;
+            const axeToSarifOutput = defaultSarifConverter21().convert(
+                axeResult,
+                {},
+            );
 
-    //         const axeRawJSON: string = fs.readFileSync(
-    //             './src/test-resources/axe-v3.2.2.reporter-raw.json',
-    //             'utf8',
-    //         );
-    //         const axeRawResult: AxeRawResult[] = JSON.parse(
-    //             axeRawJSON,
-    //         ) as AxeRawResult[];
+            const axeRawJSON: string = fs.readFileSync(
+                './src/test-resources/axe-v3.2.2.reporter-raw.json',
+                'utf8',
+            );
+            const axeRawResult: AxeRawResult[] = JSON.parse(
+                axeRawJSON,
+            ) as AxeRawResult[];
 
-    //         const environmentDataStub: EnvironmentData = {
-    //             timestamp: axeResult.timestamp,
-    //             targetPageUrl: axeResult.url,
-    //             targetPageTitle: '',
-    //         };
+            const environmentDataStub: EnvironmentData = {
+                timestamp: axeResult.timestamp,
+                targetPageUrl: axeResult.url,
+                targetPageTitle: '',
+            };
 
-    //         const axeRawToSarifOutput = testSubject.convert(
-    //             axeRawResult,
-    //             {},
-    //             environmentDataStub,
-    //         );
+            const axeRawToSarifOutput = testSubject.convert(
+                axeRawResult,
+                {},
+                environmentDataStub,
+            );
 
-    //         normalizeSarif(axeRawToSarifOutput);
-    //         normalizeSarif(axeToSarifOutput);
+            normalizeSarif(axeRawToSarifOutput);
+            normalizeSarif(axeToSarifOutput);
 
-    //         expect(axeRawToSarifOutput).toEqual(axeToSarifOutput);
-    //     });
-    // });
+            expect(axeRawToSarifOutput).toEqual(axeToSarifOutput);
+        });
+    });
 
     describe('convert', () => {
         let stubEnvironmentData: EnvironmentData;

--- a/src/axe-raw-sarif-converter-21.ts
+++ b/src/axe-raw-sarif-converter-21.ts
@@ -16,6 +16,9 @@ import { EnvironmentData } from './environment-data';
 import { getEnvironmentDataFromEnvironment } from './environment-data-provider';
 import { getInvocations21 } from './invocation-provider-21';
 import { escapeForMarkdown, isNotEmpty } from './string-utils';
+import { axeTagsToWcagLinkData, WCAGLinkData } from './wcag-link-data';
+import { WCAGLinkDataIndexer } from './wcag-link-data-indexer';
+import { getWcagTaxonomy } from './wcag-taxonomy-provider';
 
 export function defaultAxeRawSarifConverter21(): AxeRawSarifConverter21 {
     return new AxeRawSarifConverter21(
@@ -27,6 +30,12 @@ export function defaultAxeRawSarifConverter21(): AxeRawSarifConverter21 {
 }
 
 export class AxeRawSarifConverter21 {
+    private readonly tagsToWcagLinkData: DictionaryStringTo<
+        WCAGLinkData
+    > = axeTagsToWcagLinkData;
+    private readonly wcagLinkDataIndexer: WCAGLinkDataIndexer = new WCAGLinkDataIndexer(
+        this.tagsToWcagLinkData,
+    );
     public constructor(
         private getConverterToolProperties: () => Sarif.Run['conversion'],
         private getAxeProperties: () => Sarif.ToolComponent,
@@ -72,9 +81,11 @@ export class AxeRawSarifConverter21 {
                 environmentData,
             ),
             taxonomies: [
-                // getWcagTaxonomy()
+                getWcagTaxonomy(
+                    this.wcagLinkDataIndexer.getSortedWcagTags(),
+                    this.tagsToWcagLinkData,
+                ),
             ],
-            properties: {},
         };
 
         this.fillInRunPropertiesFromOptions(run, converterOptions);

--- a/src/axe-raw-sarif-converter-21.ts
+++ b/src/axe-raw-sarif-converter-21.ts
@@ -15,7 +15,6 @@ import { DictionaryStringTo } from './dictionary-types';
 import { EnvironmentData } from './environment-data';
 import { getEnvironmentDataFromEnvironment } from './environment-data-provider';
 import { getInvocations21 } from './invocation-provider-21';
-// import * as CustomSarif from './sarif/custom-sarif-types';
 import { escapeForMarkdown, isNotEmpty } from './string-utils';
 
 export function defaultAxeRawSarifConverter21(): AxeRawSarifConverter21 {

--- a/src/axe-raw-sarif-converter-21.ts
+++ b/src/axe-raw-sarif-converter-21.ts
@@ -63,7 +63,7 @@ export class AxeRawSarifConverter21 {
         converterOptions: ConverterOptions,
         environmentData: EnvironmentData,
     ): Sarif.Run {
-        const run: Sarif.Run = {
+        return {
             conversion: this.getConverterToolProperties(),
             tool: {
                 driver: {
@@ -87,10 +87,6 @@ export class AxeRawSarifConverter21 {
                 ),
             ],
         };
-
-        this.fillInRunPropertiesFromOptions(run, converterOptions);
-
-        return run;
     }
 
     private getExtraSarifResultProperties(
@@ -103,19 +99,6 @@ export class AxeRawSarifConverter21 {
             };
         }
         return extraSarifResultProperties;
-    }
-
-    private fillInRunPropertiesFromOptions(
-        run: Sarif.Run,
-        converterOptions: ConverterOptions,
-    ): void {
-        if (converterOptions.testCaseId !== undefined) {
-            run.properties!.testCaseId = converterOptions.testCaseId;
-        }
-
-        if (converterOptions.scanId !== undefined) {
-            // run.logicalId = converterOptions.scanId;
-        }
     }
 
     private convertRawResults(
@@ -225,6 +208,7 @@ export class AxeRawSarifConverter21 {
     ): Sarif.Result {
         return {
             ruleId: ruleId,
+            // TODO: add actual rule index
             // ruleIndex: 0,
             kind: 'notApplicable',
             level: 'none',
@@ -354,7 +338,6 @@ export class AxeRawSarifConverter21 {
             },
             helpUri: axeRawResult.helpUrl,
             // relationships:
-            properties: {},
         };
     }
 }

--- a/src/test-resources/basic-axe-v3.2.2-reporter-raw.json
+++ b/src/test-resources/basic-axe-v3.2.2-reporter-raw.json
@@ -23,7 +23,7 @@
             "data": null,
             "relatedNodes": [],
             "impact": "serious",
-            "message": "Document has a non-empty <title> element"
+            "message": "Document does not have a non-empty <title> element"
           }
         ],
         "all": [],


### PR DESCRIPTION
#### Description of changes

*Note: This is work in progress. There are some blocks of code commented out that will be uncommented as they are updated to support sarif v2.1.2. The integration test in `axe-raw-sarif-converter-21.test.ts` will be skipped until conversion to new sarif version is done.*

- Updated sarif version and corresponding types in `axe-raw-sarif-converter-21.ts`
- Removed `custom-sarif-types` import from `axe-raw-sarif-converter-21.ts`
- Changed message in `basic-axe-v3.2.2-reporter-raw.json` to match message in `basic-axe-v3.2.2-sarif-v2.1.2.sarif`
- Added `converter-property-provider`, `artifact-property-provider`, and `wcag-taxonomy-provider` to `axe-raw-sarif-converter-21.ts` and corresponding test
- Removed `properties` from sarif `run` output

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Addresses issue: #0000
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
