### PR TITLE
chore: output sarif results from axe raw results

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1,5 +1,712 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`axeRawSarifConverter21 converts AxeRawResults input to sarif v2.1.2 log that matches a pinned snapshot of that sarif log 1`] = `
+Object {
+  "runs": Array [
+    Object {
+      "artifacts": Array [
+        Object {
+          "location": Object {
+            "index": 0,
+            "uri": undefined,
+          },
+          "roles": Array [
+            "analysisTarget",
+          ],
+          "sourceLanguage": "html",
+        },
+      ],
+      "conversion": Object {
+        "tool": Object {
+          "driver": Object {
+            "downloadUri": "https://www.npmjs.com/package/axe-sarif-converter/v/1.3.0",
+            "fullName": "axe-sarif-converter v1.3.0",
+            "informationUri": "https://github.com/microsoft/axe-sarif-converter/releases/tag/v1.3.0",
+            "name": "axe-sarif-converter",
+            "semanticVersion": "1.3.0",
+            "version": "1.3.0",
+          },
+        },
+      },
+      "invocations": Array [
+        Object {
+          "endTimeUtc": undefined,
+          "executionSuccessful": true,
+          "startTimeUtc": undefined,
+        },
+      ],
+      "results": Array [],
+      "taxonomies": Array [
+        Object {
+          "fullName": "Web Content Accessibility Guidelines (WCAG) 2.1",
+          "guid": "ca34e0e1-5faf-4f55-a989-cdae42a98f18",
+          "informationUri": "https://www.w3.org/TR/WCAG21",
+          "isComprehensive": true,
+          "name": "WCAG",
+          "organization": "W3C",
+          "taxa": Array [
+            Object {
+              "id": "best-practice",
+              "name": "Best Practice",
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/non-text-content",
+              "id": "wcag111",
+              "name": "WCAG 1.1.1",
+              "shortDescription": Object {
+                "text": "Non-text Content",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded",
+              "id": "wcag121",
+              "name": "WCAG 1.2.1",
+              "shortDescription": Object {
+                "text": "Audio-only and Video-only (Prerecorded)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded",
+              "id": "wcag122",
+              "name": "WCAG 1.2.2",
+              "shortDescription": Object {
+                "text": "Captions (Prerecorded)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded",
+              "id": "wcag123",
+              "name": "WCAG 1.2.3",
+              "shortDescription": Object {
+                "text": "Audio Description or Media Alternative (Prerecorded)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/captions-live",
+              "id": "wcag124",
+              "name": "WCAG 1.2.4",
+              "shortDescription": Object {
+                "text": "Captions (Live)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded",
+              "id": "wcag125",
+              "name": "WCAG 1.2.5",
+              "shortDescription": Object {
+                "text": "Audio Description (Prerecorded)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/sign-language-prerecorded",
+              "id": "wcag126",
+              "name": "WCAG 1.2.6",
+              "shortDescription": Object {
+                "text": "Sign Language (Prerecorded)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/extended-audio-description-prerecorded",
+              "id": "wcag127",
+              "name": "WCAG 1.2.7",
+              "shortDescription": Object {
+                "text": "Extended Audio Description (Prerecorded)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/media-alternative-prerecorded",
+              "id": "wcag128",
+              "name": "WCAG 1.2.8",
+              "shortDescription": Object {
+                "text": "Media Alternative (Prerecorded)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-only-live",
+              "id": "wcag129",
+              "name": "WCAG 1.2.9",
+              "shortDescription": Object {
+                "text": "Audio-only (Live)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships",
+              "id": "wcag131",
+              "name": "WCAG 1.3.1",
+              "shortDescription": Object {
+                "text": "Info and Relationships",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence",
+              "id": "wcag132",
+              "name": "WCAG 1.3.2",
+              "shortDescription": Object {
+                "text": "Meaningful Sequence",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/sensory-characteristics",
+              "id": "wcag133",
+              "name": "WCAG 1.3.3",
+              "shortDescription": Object {
+                "text": "Sensory Characteristics",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/orientation",
+              "id": "wcag134",
+              "name": "WCAG 1.3.4",
+              "shortDescription": Object {
+                "text": "Orientation",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose",
+              "id": "wcag135",
+              "name": "WCAG 1.3.5",
+              "shortDescription": Object {
+                "text": "Identify Input Purpose",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/identify-purpose",
+              "id": "wcag136",
+              "name": "WCAG 1.3.6",
+              "shortDescription": Object {
+                "text": "Identify Purpose",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/use-of-color",
+              "id": "wcag141",
+              "name": "WCAG 1.4.1",
+              "shortDescription": Object {
+                "text": "Use of Color",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/reflow",
+              "id": "wcag1410",
+              "name": "WCAG 1.4.10",
+              "shortDescription": Object {
+                "text": "Reflow",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast",
+              "id": "wcag1411",
+              "name": "WCAG 1.4.11",
+              "shortDescription": Object {
+                "text": "Non-text Contrast",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/text-spacing",
+              "id": "wcag1412",
+              "name": "WCAG 1.4.12",
+              "shortDescription": Object {
+                "text": "Text Spacing",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus",
+              "id": "wcag1413",
+              "name": "WCAG 1.4.13",
+              "shortDescription": Object {
+                "text": "Content on Hover or Focus",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/audio-control",
+              "id": "wcag142",
+              "name": "WCAG 1.4.2",
+              "shortDescription": Object {
+                "text": "Audio Control",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum",
+              "id": "wcag143",
+              "name": "WCAG 1.4.3",
+              "shortDescription": Object {
+                "text": "Contrast (Minimum)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/resize-text",
+              "id": "wcag144",
+              "name": "WCAG 1.4.4",
+              "shortDescription": Object {
+                "text": "Resize text",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/images-of-text",
+              "id": "wcag145",
+              "name": "WCAG 1.4.5",
+              "shortDescription": Object {
+                "text": "Images of Text",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced",
+              "id": "wcag146",
+              "name": "WCAG 1.4.6",
+              "shortDescription": Object {
+                "text": "Contrast (Enhanced)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/low-or-no-background-audio",
+              "id": "wcag147",
+              "name": "WCAG 1.4.7",
+              "shortDescription": Object {
+                "text": "Low or No Background Audio",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation",
+              "id": "wcag148",
+              "name": "WCAG 1.4.8",
+              "shortDescription": Object {
+                "text": "Visual Presentation",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/images-of-text-no-exception",
+              "id": "wcag149",
+              "name": "WCAG 1.4.9",
+              "shortDescription": Object {
+                "text": "Images of Text (No Exception)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/keyboard",
+              "id": "wcag211",
+              "name": "WCAG 2.1.1",
+              "shortDescription": Object {
+                "text": "Keyboard",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap",
+              "id": "wcag212",
+              "name": "WCAG 2.1.2",
+              "shortDescription": Object {
+                "text": "No Keyboard Trap",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/keyboard-no-exception",
+              "id": "wcag213",
+              "name": "WCAG 2.1.3",
+              "shortDescription": Object {
+                "text": "Keyboard (No Exception)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts",
+              "id": "wcag214",
+              "name": "WCAG 2.1.4",
+              "shortDescription": Object {
+                "text": "Character Key Shortcuts",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable",
+              "id": "wcag221",
+              "name": "WCAG 2.2.1",
+              "shortDescription": Object {
+                "text": "Timing Adjustable",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide",
+              "id": "wcag222",
+              "name": "WCAG 2.2.2",
+              "shortDescription": Object {
+                "text": "Pause, Stop, Hide",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/no-timing",
+              "id": "wcag223",
+              "name": "WCAG 2.2.3",
+              "shortDescription": Object {
+                "text": "No Timing",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/interruptions",
+              "id": "wcag224",
+              "name": "WCAG 2.2.4",
+              "shortDescription": Object {
+                "text": "Interruptions",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/re-authenticating",
+              "id": "wcag225",
+              "name": "WCAG 2.2.5",
+              "shortDescription": Object {
+                "text": "Re-authenticating",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/timeouts",
+              "id": "wcag226",
+              "name": "WCAG 2.2.6",
+              "shortDescription": Object {
+                "text": "Timeouts",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold",
+              "id": "wcag231",
+              "name": "WCAG 2.3.1",
+              "shortDescription": Object {
+                "text": "Three Flashes or Below Threshold",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/three-flashes",
+              "id": "wcag232",
+              "name": "WCAG 2.3.2",
+              "shortDescription": Object {
+                "text": "Three Flashes",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions",
+              "id": "wcag233",
+              "name": "WCAG 2.3.3",
+              "shortDescription": Object {
+                "text": "Animation from Interactions",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks",
+              "id": "wcag241",
+              "name": "WCAG 2.4.1",
+              "shortDescription": Object {
+                "text": "Bypass Blocks",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/section-headings",
+              "id": "wcag2410",
+              "name": "WCAG 2.4.10",
+              "shortDescription": Object {
+                "text": "Section Headings",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/page-titled",
+              "id": "wcag242",
+              "name": "WCAG 2.4.2",
+              "shortDescription": Object {
+                "text": "Page Titled",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/focus-order",
+              "id": "wcag243",
+              "name": "WCAG 2.4.3",
+              "shortDescription": Object {
+                "text": "Focus Order",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context",
+              "id": "wcag244",
+              "name": "WCAG 2.4.4",
+              "shortDescription": Object {
+                "text": "Link Purpose (In Context)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/multiple-ways",
+              "id": "wcag245",
+              "name": "WCAG 2.4.5",
+              "shortDescription": Object {
+                "text": "Multiple Ways",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels",
+              "id": "wcag246",
+              "name": "WCAG 2.4.6",
+              "shortDescription": Object {
+                "text": "Headings and Labels",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/focus-visible",
+              "id": "wcag247",
+              "name": "WCAG 2.4.7",
+              "shortDescription": Object {
+                "text": "Focus Visible",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/location",
+              "id": "wcag248",
+              "name": "WCAG 2.4.8",
+              "shortDescription": Object {
+                "text": "Location",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only",
+              "id": "wcag249",
+              "name": "WCAG 2.4.9",
+              "shortDescription": Object {
+                "text": "Link Purpose (Link Only)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures",
+              "id": "wcag251",
+              "name": "WCAG 2.5.1",
+              "shortDescription": Object {
+                "text": "Pointer Gestures",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation",
+              "id": "wcag252",
+              "name": "WCAG 2.5.2",
+              "shortDescription": Object {
+                "text": "Pointer Cancellation",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/label-in-name",
+              "id": "wcag253",
+              "name": "WCAG 2.5.3",
+              "shortDescription": Object {
+                "text": "Label in Name",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation",
+              "id": "wcag254",
+              "name": "WCAG 2.5.4",
+              "shortDescription": Object {
+                "text": "Motion Actuation",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/target-size",
+              "id": "wcag255",
+              "name": "WCAG 2.5.5",
+              "shortDescription": Object {
+                "text": "Target Size",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/concurrent-input-mechanisms",
+              "id": "wcag256",
+              "name": "WCAG 2.5.6",
+              "shortDescription": Object {
+                "text": "Concurrent Input Mechanisms",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/language-of-page",
+              "id": "wcag311",
+              "name": "WCAG 3.1.1",
+              "shortDescription": Object {
+                "text": "Language of Page",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts",
+              "id": "wcag312",
+              "name": "WCAG 3.1.2",
+              "shortDescription": Object {
+                "text": "Language of Parts",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/unusual-words",
+              "id": "wcag313",
+              "name": "WCAG 3.1.3",
+              "shortDescription": Object {
+                "text": "Unusual Words",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/abbreviations",
+              "id": "wcag314",
+              "name": "WCAG 3.1.4",
+              "shortDescription": Object {
+                "text": "Abbreviations",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/reading-level",
+              "id": "wcag315",
+              "name": "WCAG 3.1.5",
+              "shortDescription": Object {
+                "text": "Reading Level",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/pronunciation",
+              "id": "wcag316",
+              "name": "WCAG 3.1.6",
+              "shortDescription": Object {
+                "text": "Pronunciation",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/on-focus",
+              "id": "wcag321",
+              "name": "WCAG 3.2.1",
+              "shortDescription": Object {
+                "text": "On Focus",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/on-input",
+              "id": "wcag322",
+              "name": "WCAG 3.2.2",
+              "shortDescription": Object {
+                "text": "On Input",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation",
+              "id": "wcag323",
+              "name": "WCAG 3.2.3",
+              "shortDescription": Object {
+                "text": "Consistent Navigation",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification",
+              "id": "wcag324",
+              "name": "WCAG 3.2.4",
+              "shortDescription": Object {
+                "text": "Consistent Identification",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/change-on-request",
+              "id": "wcag325",
+              "name": "WCAG 3.2.5",
+              "shortDescription": Object {
+                "text": "Change on Request",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-identification",
+              "id": "wcag331",
+              "name": "WCAG 3.3.1",
+              "shortDescription": Object {
+                "text": "Error Identification",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions",
+              "id": "wcag332",
+              "name": "WCAG 3.3.2",
+              "shortDescription": Object {
+                "text": "Labels or Instructions",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-suggestion",
+              "id": "wcag333",
+              "name": "WCAG 3.3.3",
+              "shortDescription": Object {
+                "text": "Error Suggestion",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data",
+              "id": "wcag334",
+              "name": "WCAG 3.3.4",
+              "shortDescription": Object {
+                "text": "Error Prevention (Legal, Financial, Data)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/help",
+              "id": "wcag335",
+              "name": "WCAG 3.3.5",
+              "shortDescription": Object {
+                "text": "Help",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-all",
+              "id": "wcag336",
+              "name": "WCAG 3.3.6",
+              "shortDescription": Object {
+                "text": "Error Prevention (All)",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/parsing",
+              "id": "wcag411",
+              "name": "WCAG 4.1.1",
+              "shortDescription": Object {
+                "text": "Parsing",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/name-role-value",
+              "id": "wcag412",
+              "name": "WCAG 4.1.2",
+              "shortDescription": Object {
+                "text": "Name, Role, Value",
+              },
+            },
+            Object {
+              "helpUri": "https://www.w3.org/WAI/WCAG21/Understanding/status-messages",
+              "id": "wcag413",
+              "name": "WCAG 4.1.3",
+              "shortDescription": Object {
+                "text": "Status Messages",
+              },
+            },
+          ],
+          "version": "2.1",
+        },
+      ],
+      "tool": Object {
+        "driver": Object {
+          "downloadUri": "https://www.npmjs.com/package/axe-core/v/3.2.2",
+          "fullName": "axe for Web v3.2.2",
+          "informationUri": "https://www.deque.com/axe/axe-for-web/",
+          "name": "axe-core",
+          "properties": Object {
+            "microsoft/qualityDomain": "Accessibility",
+          },
+          "rules": Array [],
+          "semanticVersion": "3.2.2",
+          "shortDescription": Object {
+            "text": "An open source accessibility rules library for automated testing.",
+          },
+          "supportedTaxonomies": Array [
+            Object {
+              "guid": "ca34e0e1-5faf-4f55-a989-cdae42a98f18",
+              "index": 0,
+              "name": "WCAG",
+            },
+          ],
+          "version": "3.2.2",
+        },
+      },
+    },
+  ],
+  "version": "2.1.0",
+}
+`;
+
 exports[`axeToSarifConverter use generated AxeResults object matches pinned snapshot of sarifv2 generated from an actual AxeResults object 1`] = `
 Object {
   "runs": Array [

--- a/src/axe-raw-result.ts
+++ b/src/axe-raw-result.ts
@@ -36,6 +36,7 @@ export interface AxeRawCheckResult {
 export interface AxeRawNode {
     selector: Selector;
     source: string;
+    xpath: string[];
 }
 
 export type ResultValue = 'passed' | 'failed' | 'inapplicable' | 'cantTell';

--- a/src/axe-raw-sarif-converter-21.test.ts
+++ b/src/axe-raw-sarif-converter-21.test.ts
@@ -60,7 +60,6 @@ describe('AxeRawSarifConverter21', () => {
             const environmentDataStub: EnvironmentData = {
                 timestamp: axeResult.timestamp,
                 targetPageUrl: axeResult.url,
-                targetPageTitle: '',
             };
 
             const axeRawToSarifOutput = testSubject.convert(


### PR DESCRIPTION
#### Description of changes

- Added `xpath` to `axe-raw-results.ts` typings file
- Modified format of sarif results output to match sarif v2.1.2 in `axe-raw-sarif-converter-21.ts`
- Added tests to `index.test.ts` with fixed `environmentData` to match environment data in sample sarif output (`basic-axe-v3.2.2-sarif-v2.1.2.sarif`)

#### Pull request checklist

- [] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Implements WI: 1553645
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
