### PR TITLE
refactor: move message formatter to new file

### DIFF
--- a/src/sarif-result-message-formatter.test.ts
+++ b/src/sarif-result-message-formatter.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as Axe from 'axe-core';
+import * as Sarif from 'sarif';
+import { formatSarifResultMessage } from './sarif-result-message-formatter';
+
+describe('sarif-result-message-formatter formatSarifResultMessage', () => {
+    const expectedResults: Sarif.Message[] = [
+        // fail
+        {
+            text:
+                'Fix all of the following: stub_node_message_all[0]. stub_node_message_none[0]. ' +
+                'Fix any of the following: stub_node_message_any[0]. stub_node_id_any[1].',
+            markdown:
+                'Fix all of the following:\n- stub_node_message_all[0].\n- stub_node_message_none[0].\n\n' +
+                'Fix any of the following:\n- stub_node_message_any[0].\n- stub_node_id_any[1].',
+        },
+        // not fail
+        {
+            text:
+                'The following tests passed: stub_node_message_all[0]. stub_node_message_none[0]. ' +
+                'stub_node_message_any[0]. stub_node_id_any[1].',
+            markdown:
+                'The following tests passed:\n- stub_node_message_all[0].\n- stub_node_message_none[0].\n' +
+                '- stub_node_message_any[0].\n- stub_node_id_any[1].',
+        },
+    ];
+
+    let stub_node: Axe.NodeResult;
+    beforeAll(() => {
+        stub_node = {
+            any: [
+                {
+                    id: 'stub_node_id_any[0]',
+                    message: 'stub_node_message_any[0]',
+                },
+                {
+                    id: 'stub_node_id_any[1]',
+                },
+            ],
+            all: [
+                {
+                    id: 'stub_node_id_all[0]',
+                    message: 'stub_node_message_all[0]',
+                },
+            ],
+            none: [
+                {
+                    id: 'stub_node_id_none[0]',
+                    message: 'stub_node_message_none[0]',
+                },
+            ],
+        } as Axe.NodeResult;
+    });
+
+    it('proudces expected Sarif Message for kind: fail', () => {
+        const actualResults: Sarif.Message = formatSarifResultMessage(
+            stub_node,
+            'fail',
+        );
+
+        expect(actualResults).toEqual(expectedResults[0]);
+    });
+
+    it('produces expected Sarif Message for kind: pass', () => {
+        const actualResults: Sarif.Message = formatSarifResultMessage(
+            stub_node,
+            'pass',
+        );
+
+        expect(actualResults).toEqual(expectedResults[1]);
+    });
+});

--- a/src/sarif-result-message-formatter.test.ts
+++ b/src/sarif-result-message-formatter.test.ts
@@ -53,7 +53,7 @@ describe('sarif-result-message-formatter formatSarifResultMessage', () => {
         } as Axe.NodeResult;
     });
 
-    it('proudces expected Sarif Message for kind: fail', () => {
+    it('produces expected Sarif Message for kind: fail', () => {
         const actualResults: Sarif.Message = formatSarifResultMessage(
             stub_node,
             'fail',

--- a/src/sarif-result-message-formatter.ts
+++ b/src/sarif-result-message-formatter.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as Sarif from 'sarif';
+import { AxeRawCheckResult, AxeRawNodeResult } from './axe-raw-result';
+import { escapeForMarkdown, isNotEmpty } from './string-utils';
+
+export function formatSarifResultMessage(
+    node: AxeRawNodeResult,
+    kind: Sarif.Result.kind,
+): Sarif.Message {
+    const textArray: string[] = [];
+    const markdownArray: string[] = [];
+
+    if (kind === 'fail') {
+        const allAndNone = node.all.concat(node.none);
+        formatSarifCheckResultsMessage(
+            'Fix all of the following:',
+            allAndNone,
+            textArray,
+            markdownArray,
+        );
+        formatSarifCheckResultsMessage(
+            'Fix any of the following:',
+            node.any,
+            textArray,
+            markdownArray,
+        );
+    } else {
+        const allNodes = node.all.concat(node.none).concat(node.any);
+        formatSarifCheckResultsMessage(
+            'The following tests passed:',
+            allNodes,
+            textArray,
+            markdownArray,
+        );
+    }
+
+    return {
+        text: textArray.join(' '),
+        markdown: markdownArray.join('\n\n'),
+    };
+}
+
+function formatSarifCheckResultsMessage(
+    heading: string,
+    checkResults: AxeRawCheckResult[],
+    textArray: string[],
+    markdownArray: string[],
+): void {
+    if (checkResults.length > 0) {
+        const textLines: string[] = [];
+        const markdownLines: string[] = [];
+
+        textLines.push(heading);
+        markdownLines.push(escapeForMarkdown(heading));
+
+        for (const checkResult of checkResults) {
+            const message = isNotEmpty(checkResult.message)
+                ? checkResult.message
+                : checkResult.id;
+
+            textLines.push(message + '.');
+            markdownLines.push('- ' + escapeForMarkdown(message) + '.');
+        }
+
+        textArray.push(textLines.join(' '));
+        markdownArray.push(markdownLines.join('\n'));
+    }
+}

--- a/src/sarif-result-message-formatter.ts
+++ b/src/sarif-result-message-formatter.ts
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as Axe from 'axe-core';
 import * as Sarif from 'sarif';
 import { AxeRawCheckResult, AxeRawNodeResult } from './axe-raw-result';
 import { escapeForMarkdown, isNotEmpty } from './string-utils';
 
 export function formatSarifResultMessage(
-    node: AxeRawNodeResult,
+    node: Axe.NodeResult | AxeRawNodeResult,
     kind: Sarif.Result.kind,
 ): Sarif.Message {
     const textArray: string[] = [];
     const markdownArray: string[] = [];
 
     if (kind === 'fail') {
-        const allAndNone = node.all.concat(node.none);
+        const allAndNone = (node.all as any).concat(node.none);
         formatSarifCheckResultsMessage(
             'Fix all of the following:',
             allAndNone,
@@ -26,7 +27,7 @@ export function formatSarifResultMessage(
             markdownArray,
         );
     } else {
-        const allNodes = node.all.concat(node.none).concat(node.any);
+        const allNodes = (node.all as any).concat(node.none).concat(node.any);
         formatSarifCheckResultsMessage(
             'The following tests passed:',
             allNodes,
@@ -43,7 +44,7 @@ export function formatSarifResultMessage(
 
 function formatSarifCheckResultsMessage(
     heading: string,
-    checkResults: AxeRawCheckResult[],
+    checkResults: Axe.CheckResult[] | AxeRawCheckResult[],
     textArray: string[],
     markdownArray: string[],
 ): void {


### PR DESCRIPTION
#### Description of changes

- Moved message formatting functions to new file `sarif-result-message-formatter.ts` because they are common to `sarif-converter-21` and `axe-raw-sarif-converter-21`
- Added tests for `sarif-result-message-formatter`

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Partially implements WI: 1515731
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
