### PR TITLE
chore: get converter version from package json

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -19,12 +19,12 @@ Object {
       "conversion": Object {
         "tool": Object {
           "driver": Object {
-            "downloadUri": "https://www.npmjs.com/package/axe-sarif-converter/v/1.3.0",
-            "fullName": "axe-sarif-converter v1.3.0",
-            "informationUri": "https://github.com/microsoft/axe-sarif-converter/releases/tag/v1.3.0",
+            "downloadUri": "https://www.npmjs.com/package/axe-sarif-converter/v/0.0.0-managed-by-semantic-release",
+            "fullName": "axe-sarif-converter v0.0.0-managed-by-semantic-release",
+            "informationUri": "https://github.com/microsoft/axe-sarif-converter/releases/tag/v0.0.0-managed-by-semantic-release",
             "name": "axe-sarif-converter",
-            "semanticVersion": "1.3.0",
-            "version": "1.3.0",
+            "semanticVersion": "0.0.0-managed-by-semantic-release",
+            "version": "0.0.0-managed-by-semantic-release",
           },
         },
       },
@@ -15174,12 +15174,12 @@ Object {
       "conversion": Object {
         "tool": Object {
           "driver": Object {
-            "downloadUri": "https://www.npmjs.com/package/axe-sarif-converter/v/1.3.0",
-            "fullName": "axe-sarif-converter v1.3.0",
-            "informationUri": "https://github.com/microsoft/axe-sarif-converter/releases/tag/v1.3.0",
+            "downloadUri": "https://www.npmjs.com/package/axe-sarif-converter/v/0.0.0-managed-by-semantic-release",
+            "fullName": "axe-sarif-converter v0.0.0-managed-by-semantic-release",
+            "informationUri": "https://github.com/microsoft/axe-sarif-converter/releases/tag/v0.0.0-managed-by-semantic-release",
             "name": "axe-sarif-converter",
-            "semanticVersion": "1.3.0",
-            "version": "1.3.0",
+            "semanticVersion": "0.0.0-managed-by-semantic-release",
+            "version": "0.0.0-managed-by-semantic-release",
           },
         },
       },

--- a/src/converter-property-provider.test.ts
+++ b/src/converter-property-provider.test.ts
@@ -6,17 +6,21 @@ import { getConverterProperties } from './converter-property-provider';
 describe('converter-property-provider', () => {
     describe('getConverterProperties', () => {
         it('returns the converter properties as a Sarif.Run["conversion"', () => {
+            var packagejson = require('../package.json');
+            const version = packagejson.version;
             const expectedResults: Sarif.Run['conversion'] = {
                 tool: {
                     driver: {
                         name: 'axe-sarif-converter',
-                        fullName: 'axe-sarif-converter v1.3.0',
-                        version: '1.3.0',
-                        semanticVersion: '1.3.0',
+                        fullName: 'axe-sarif-converter v' + version,
+                        version: version,
+                        semanticVersion: version,
                         informationUri:
-                            'https://github.com/microsoft/axe-sarif-converter/releases/tag/v1.3.0',
+                            'https://github.com/microsoft/axe-sarif-converter/releases/tag/v' +
+                            version,
                         downloadUri:
-                            'https://www.npmjs.com/package/axe-sarif-converter/v/1.3.0',
+                            'https://www.npmjs.com/package/axe-sarif-converter/v/' +
+                            version,
                     },
                 },
             };

--- a/src/converter-property-provider.ts
+++ b/src/converter-property-provider.ts
@@ -3,17 +3,21 @@
 import * as Sarif from 'sarif';
 
 export function getConverterProperties(): Sarif.Run['conversion'] {
+    var packagejson = require('../package.json');
+    const version = packagejson.version;
     return {
         tool: {
             driver: {
                 name: 'axe-sarif-converter',
-                fullName: 'axe-sarif-converter v1.3.0',
-                version: '1.3.0',
-                semanticVersion: '1.3.0',
+                fullName: 'axe-sarif-converter v' + version,
+                version: version,
+                semanticVersion: version,
                 informationUri:
-                    'https://github.com/microsoft/axe-sarif-converter/releases/tag/v1.3.0',
+                    'https://github.com/microsoft/axe-sarif-converter/releases/tag/v' +
+                    version,
                 downloadUri:
-                    'https://www.npmjs.com/package/axe-sarif-converter/v/1.3.0',
+                    'https://www.npmjs.com/package/axe-sarif-converter/v/' +
+                    version,
             },
         },
     };

--- a/src/test-resources/basic-axe-v3.2.2-sarif-v2.1.2.sarif
+++ b/src/test-resources/basic-axe-v3.2.2-sarif-v2.1.2.sarif
@@ -6,11 +6,11 @@
           "tool": {
             "driver": {
               "name": "axe-sarif-converter",
-              "fullName": "axe-sarif-converter v1.3.0",
-              "version": "1.3.0",
-              "semanticVersion": "1.3.0",
-              "informationUri": "https://github.com/microsoft/axe-sarif-converter/releases/tag/v1.3.0",
-              "downloadUri": "https://www.npmjs.com/package/axe-sarif-converter/v/1.3.0"
+              "fullName": "axe-sarif-converter v0.0.0-managed-by-semantic-release",
+              "version": "0.0.0-managed-by-semantic-release",
+              "semanticVersion": "0.0.0-managed-by-semantic-release",
+              "informationUri": "https://github.com/microsoft/axe-sarif-converter/releases/tag/v0.0.0-managed-by-semantic-release",
+              "downloadUri": "https://www.npmjs.com/package/axe-sarif-converter/v/0.0.0-managed-by-semantic-release"
             }
           }
         },


### PR DESCRIPTION
#### Description of changes

- Updated `converter-property-provider` to automatically populate version number from `package.json`
- Updated snapshot and `basic-axe-v3.2.2-sarif-v2.1.2.sarif` sample output accordingly

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Implements WI: 1553476
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
