### PR TITLE
chore: add version mapping info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ test('my accessibility test', async () => {
 
 The [microsoft/axe-pipelines-samples](https://github.com/microsoft/axe-pipelines-samples) project contains full sample code that walks you through integrating this library into your project, from writing a test to seeing results in Azure Pipelines.
 
+## Version numbers
+
+The version number of this library is **independent** from the version numbers of the axe-core inputs and SARIF outputs it supports.
+
+-   axe-sarif-converter versions 2.x supports input from version ^3.0.0 of axe-core and outputs SARIF v2.1
+-   axe-sarif-converter versions 1.x supports input from version ^3.0.0 of axe-core and outputs SARIF v2.0
+
+Note that the SARIF format _does not use semantic versioning_, and there are breaking changes between v2.0 and v2.1 SARIF files. If you need compatibility with a SARIF viewer that only supports v2.0, you should use version 1.x of this library.
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ The [microsoft/axe-pipelines-samples](https://github.com/microsoft/axe-pipelines
 
 The version number of this library is **independent** from the version numbers of the axe-core inputs and SARIF outputs it supports.
 
--   axe-sarif-converter versions 2.x supports input from version ^3.0.0 of axe-core and outputs SARIF v2.1
--   axe-sarif-converter versions 1.x supports input from version ^3.0.0 of axe-core and outputs SARIF v2.0
+-   axe-sarif-converter version 2.x supports input from version ^3.0.0 of axe-core and outputs SARIF v2.1
+-   axe-sarif-converter version 1.x supports input from version ^3.0.0 of axe-core and outputs SARIF v2.0
 
-Note that the SARIF format _does not use semantic versioning_, and there are breaking changes between v2.0 and v2.1 SARIF files. If you need compatibility with a SARIF viewer that only supports v2.0, you should use version 1.x of this library.
+Note that the SARIF format _does not use semantic versioning_, and there are breaking changes between the v2.0 and v2.1 SARIF formats. If you need compatibility with a SARIF viewer that only supports v2.0, you should use version 1.x of this library.
 
 ## Contributing
 


### PR DESCRIPTION
#### Description of changes

Adds a "Version numbers" section to the README that describes the mappings between axe-sarif-converter version and axe-core/SARIF format versions.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Addresses issue: #0000
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
