### PR TITLE
chore: add period to end of message for results without nodes

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -27235,7 +27235,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures every accesskey attribute value is unique",
+            "text": "Ensures every accesskey attribute value is unique.",
           },
           "ruleId": "accesskeys",
           "ruleIndex": 0,
@@ -27244,7 +27244,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <area> elements of image maps have alternate text",
+            "text": "Ensures <area> elements of image maps have alternate text.",
           },
           "ruleId": "area-alt",
           "ruleIndex": 1,
@@ -27253,7 +27253,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures ARIA attributes are allowed for an element's role",
+            "text": "Ensures ARIA attributes are allowed for an element's role.",
           },
           "ruleId": "aria-allowed-attr",
           "ruleIndex": 2,
@@ -27262,7 +27262,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures role attribute has an appropriate value for the element",
+            "text": "Ensures role attribute has an appropriate value for the element.",
           },
           "ruleId": "aria-allowed-role",
           "ruleIndex": 3,
@@ -27271,7 +27271,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures unsupported DPUB roles are only used on elements with implicit fallback roles",
+            "text": "Ensures unsupported DPUB roles are only used on elements with implicit fallback roles.",
           },
           "ruleId": "aria-dpub-role-fallback",
           "ruleIndex": 4,
@@ -27280,7 +27280,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures aria-hidden elements do not contain focusable elements",
+            "text": "Ensures aria-hidden elements do not contain focusable elements.",
           },
           "ruleId": "aria-hidden-focus",
           "ruleIndex": 6,
@@ -27289,7 +27289,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures elements with ARIA roles have all required ARIA attributes",
+            "text": "Ensures elements with ARIA roles have all required ARIA attributes.",
           },
           "ruleId": "aria-required-attr",
           "ruleIndex": 7,
@@ -27298,7 +27298,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures elements with an ARIA role that require child roles contain them",
+            "text": "Ensures elements with an ARIA role that require child roles contain them.",
           },
           "ruleId": "aria-required-children",
           "ruleIndex": 8,
@@ -27307,7 +27307,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures elements with an ARIA role that require parent roles are contained by them",
+            "text": "Ensures elements with an ARIA role that require parent roles are contained by them.",
           },
           "ruleId": "aria-required-parent",
           "ruleIndex": 9,
@@ -27316,7 +27316,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures all elements with a role attribute use a valid value",
+            "text": "Ensures all elements with a role attribute use a valid value.",
           },
           "ruleId": "aria-roles",
           "ruleIndex": 10,
@@ -27325,7 +27325,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures all ARIA attributes have valid values",
+            "text": "Ensures all ARIA attributes have valid values.",
           },
           "ruleId": "aria-valid-attr-value",
           "ruleIndex": 12,
@@ -27334,7 +27334,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures attributes that begin with aria- are valid ARIA attributes",
+            "text": "Ensures attributes that begin with aria- are valid ARIA attributes.",
           },
           "ruleId": "aria-valid-attr",
           "ruleIndex": 11,
@@ -27343,7 +27343,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensure the autocomplete attribute is correct and suitable for the form field",
+            "text": "Ensure the autocomplete attribute is correct and suitable for the form field.",
           },
           "ruleId": "autocomplete-valid",
           "ruleIndex": 13,
@@ -27352,7 +27352,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <blink> elements are not used",
+            "text": "Ensures <blink> elements are not used.",
           },
           "ruleId": "blink",
           "ruleIndex": 14,
@@ -27361,7 +27361,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures buttons have discernible text",
+            "text": "Ensures buttons have discernible text.",
           },
           "ruleId": "button-name",
           "ruleIndex": 15,
@@ -27370,7 +27370,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures related <input type=\\"checkbox\\"> elements have a group and that the group designation is consistent",
+            "text": "Ensures related <input type=\\"checkbox\\"> elements have a group and that the group designation is consistent.",
           },
           "ruleId": "checkboxgroup",
           "ruleIndex": 17,
@@ -27379,7 +27379,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <dl> elements are structured correctly",
+            "text": "Ensures <dl> elements are structured correctly.",
           },
           "ruleId": "definition-list",
           "ruleIndex": 19,
@@ -27388,7 +27388,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <dt> and <dd> elements are contained by a <dl>",
+            "text": "Ensures <dt> and <dd> elements are contained by a <dl>.",
           },
           "ruleId": "dlitem",
           "ruleIndex": 20,
@@ -27397,7 +27397,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures every id attribute value of active elements is unique",
+            "text": "Ensures every id attribute value of active elements is unique.",
           },
           "ruleId": "duplicate-id-active",
           "ruleIndex": 23,
@@ -27406,7 +27406,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures every id attribute value used in ARIA and in labels is unique",
+            "text": "Ensures every id attribute value used in ARIA and in labels is unique.",
           },
           "ruleId": "duplicate-id-aria",
           "ruleIndex": 24,
@@ -27415,7 +27415,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <iframe> and <frame> elements contain the axe-core script",
+            "text": "Ensures <iframe> and <frame> elements contain the axe-core script.",
           },
           "ruleId": "frame-tested",
           "ruleIndex": 27,
@@ -27424,7 +27424,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <iframe> and <frame> elements contain a unique title attribute",
+            "text": "Ensures <iframe> and <frame> elements contain a unique title attribute.",
           },
           "ruleId": "frame-title-unique",
           "ruleIndex": 29,
@@ -27433,7 +27433,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+            "text": "Ensures <iframe> and <frame> elements contain a non-empty title attribute.",
           },
           "ruleId": "frame-title",
           "ruleIndex": 28,
@@ -27442,7 +27442,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures the lang attribute of the <html> element has a valid value",
+            "text": "Ensures the lang attribute of the <html> element has a valid value.",
           },
           "ruleId": "html-lang-valid",
           "ruleIndex": 32,
@@ -27451,7 +27451,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page",
+            "text": "Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page.",
           },
           "ruleId": "html-xml-lang-mismatch",
           "ruleIndex": 33,
@@ -27460,7 +27460,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <input type=\\"image\\"> elements have alternate text",
+            "text": "Ensures <input type=\\"image\\"> elements have alternate text.",
           },
           "ruleId": "input-image-alt",
           "ruleIndex": 36,
@@ -27469,7 +27469,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures the banner landmark is at top level",
+            "text": "Ensures the banner landmark is at top level.",
           },
           "ruleId": "landmark-banner-is-top-level",
           "ruleIndex": 39,
@@ -27478,7 +27478,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures the complementary landmark or aside is at top level",
+            "text": "Ensures the complementary landmark or aside is at top level.",
           },
           "ruleId": "landmark-complementary-is-top-level",
           "ruleIndex": 40,
@@ -27487,7 +27487,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures the contentinfo landmark is at top level",
+            "text": "Ensures the contentinfo landmark is at top level.",
           },
           "ruleId": "landmark-contentinfo-is-top-level",
           "ruleIndex": 41,
@@ -27496,7 +27496,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures the main landmark is at top level",
+            "text": "Ensures the main landmark is at top level.",
           },
           "ruleId": "landmark-main-is-top-level",
           "ruleIndex": 42,
@@ -27505,7 +27505,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <marquee> elements are not used",
+            "text": "Ensures <marquee> elements are not used.",
           },
           "ruleId": "marquee",
           "ruleIndex": 50,
@@ -27514,7 +27514,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <meta http-equiv=\\"refresh\\"> is not used",
+            "text": "Ensures <meta http-equiv=\\"refresh\\"> is not used.",
           },
           "ruleId": "meta-refresh",
           "ruleIndex": 51,
@@ -27523,7 +27523,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <meta name=\\"viewport\\"> can scale a significant amount",
+            "text": "Ensures <meta name=\\"viewport\\"> can scale a significant amount.",
           },
           "ruleId": "meta-viewport-large",
           "ruleIndex": 53,
@@ -27532,7 +27532,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <meta name=\\"viewport\\"> does not disable text scaling and zooming",
+            "text": "Ensures <meta name=\\"viewport\\"> does not disable text scaling and zooming.",
           },
           "ruleId": "meta-viewport",
           "ruleIndex": 52,
@@ -27541,7 +27541,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <object> elements have alternate text",
+            "text": "Ensures <object> elements have alternate text.",
           },
           "ruleId": "object-alt",
           "ruleIndex": 54,
@@ -27550,7 +27550,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures related <input type=\\"radio\\"> elements have a group and that the group designation is consistent",
+            "text": "Ensures related <input type=\\"radio\\"> elements have a group and that the group designation is consistent.",
           },
           "ruleId": "radiogroup",
           "ruleIndex": 56,
@@ -27559,7 +27559,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures the scope attribute is used correctly on tables",
+            "text": "Ensures the scope attribute is used correctly on tables.",
           },
           "ruleId": "scope-attr-valid",
           "ruleIndex": 58,
@@ -27568,7 +27568,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures that server-side image maps are not used",
+            "text": "Ensures that server-side image maps are not used.",
           },
           "ruleId": "server-side-image-map",
           "ruleIndex": 59,
@@ -27577,7 +27577,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures tabindex attribute values are not greater than 0",
+            "text": "Ensures tabindex attribute values are not greater than 0.",
           },
           "ruleId": "tabindex",
           "ruleIndex": 61,
@@ -27586,7 +27586,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensure that each table header in a data table refers to data cells",
+            "text": "Ensure that each table header in a data table refers to data cells.",
           },
           "ruleId": "th-has-data-cells",
           "ruleIndex": 64,
@@ -27595,7 +27595,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures lang attributes have valid values",
+            "text": "Ensures lang attributes have valid values.",
           },
           "ruleId": "valid-lang",
           "ruleIndex": 65,
@@ -27604,7 +27604,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <video> elements have captions",
+            "text": "Ensures <video> elements have captions.",
           },
           "ruleId": "video-caption",
           "ruleIndex": 66,
@@ -27613,7 +27613,7 @@ Fix any of the following:
           "kind": "notApplicable",
           "level": "none",
           "message": Object {
-            "text": "Ensures <video> elements have audio descriptions",
+            "text": "Ensures <video> elements have audio descriptions.",
           },
           "ruleId": "video-description",
           "ruleIndex": 67,

--- a/src/axe-raw-sarif-converter-21.ts
+++ b/src/axe-raw-sarif-converter-21.ts
@@ -216,7 +216,7 @@ export class AxeRawSarifConverter21 {
             kind: 'notApplicable',
             level: 'none',
             message: {
-                text: ruleDescription,
+                text: ruleDescription + '.',
             },
         };
     }

--- a/src/sarif-converter-21.ts
+++ b/src/sarif-converter-21.ts
@@ -220,7 +220,7 @@ export class SarifConverter21 {
                     kind: kind,
                     level: this.getResultLevelFromResultKind(kind),
                     message: {
-                        text: ruleResult.description,
+                        text: ruleResult.description + '.',
                     },
                 });
             }


### PR DESCRIPTION
#### Description of changes

- Added period to end of result `message` text for results without nodes to comply with sarif schema
- Updated relevant snapshot

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Addresses issue: #0000 **N/A**
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
