### PR TITLE
chore: fix wallaby config to enable tests that use test-resources files

### DIFF
--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -8,6 +8,7 @@ module.exports = function() {
             'tsconfig.json',
             'jest.config.js',
             'src/**/*.ts',
+            'src/test-resources/*',
             { pattern: 'src/**/*.test.ts', ignore: true },
         ],
         tests: ['src/**/*.test.ts'],


### PR DESCRIPTION
#### Description of changes

We never updated our wallaby configuration to understand our `/src/test-resources` folder, so there were false failures from wallaby in tests that read from them. This fixes those false failures.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Addresses issue: #0000
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
