### PR TITLE
fix: remove the recent yarn engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
         "README.md"
     ],
     "engines": {
-        "node": ">= 8",
-        "yarn": "^1.15.1"
+        "node": ">= 8"
     },
     "dependencies": {
         "@types/sarif": "2.1.1",


### PR DESCRIPTION
#### Description of changes

Previously, we set an engine requirement of `"yarn": "^1.15.1"`, which forced prospective consumers to use pretty recent yarn versions in their consuming projects even though we don't actually need any recent yarn features. We aren't doing anything special in our package.json; we don't need to require *any* single specific package manager (npm, yarn, etc are fine to consume the project with), so this just removes the package manager engine requirement outright.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Addresses issue: #70 
- [n/a] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
