### PR TITLE
fix: widen @types/sarif dependency to accept both 2.1.1 and 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "node": ">= 8"
     },
     "dependencies": {
-        "@types/sarif": "2.1.2",
+        "@types/sarif": ">=2.1.1 <=2.1.2",
         "axe-core": "^3.2.2"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,7 +533,7 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
-"@types/sarif@2.1.2":
+"@types/sarif@>=2.1.1 <=2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@types/sarif/-/sarif-2.1.2.tgz#91d9f9e793fadbba36239f03ec996987b2e25635"
   integrity sha512-TELZl5h48KaB6SFZqTuaMEw1hrGuusbBcH+yfMaaHdS2pwDr3RTH4CVN0LyY1kqSiDm9PPvAMx8FJ0LUZreOCQ==


### PR DESCRIPTION
#### Description of changes

@types/sarif received a non-breaking update with 2.1.1 -> 2.1.2. This widens the range this library claims support for to include both versions.

It continues to use a strict upper bound rather than a caret version, since the SARIF standard and correspondingly @types/sarif have historically been willing to make breaking changes in patch versions (eg, from 2.1.0 -> 2.1.1).

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
