### PR TITLE
chore: generalize CODEOWNERS to use whole-team instead of web-specific team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners for everything in the repository.
-*   @microsoft/accessibility-insights-web-code-owners
+*   @microsoft/accessibility-insights-code-owners


### PR DESCRIPTION
#### Description of changes

We've started updating all the accessibility insights repos to use a shared CODEOWNERS team, rather than maintaining separate ones per project. This brings axe-sarif-converter up to date with this new policy.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [n/a] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
