### PR TITLE
chore: have release builds use secrets from KeyVault rather than pipeline variables

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,6 @@ jobs:
           - script: yarn semantic-release
             displayName: yarn semantic-release (master branch only)
             env:
-                GH_TOKEN: $(GH_TOKEN)
-                NPM_TOKEN: $(NPM_TOKEN)
+                GH_TOKEN: $(github-ada-cat-auth-token)
+                NPM_TOKEN: $(npmjs-accessibility-insights-team-publish-auth-token)
             condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['EnableSemanticRelease'], 'true'))


### PR DESCRIPTION
#### Description of changes

Previously, the release build for the package was using its own copy of GH_TOKEN and NPM_TOKEN specified as secret variables on the private release build pipeline. This updates them to instead use the variables from the KeyVault-backed variable group, to make rotating the secrets easier in the future.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
