### PR TITLE
feat: add $schema to outputted files

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`public convertAxeToSarif API converts minimal axe v2 input with no results to the pinned minimal SARIF output 1`] = `
 Object {
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": Array [
     Object {
       "artifacts": Array [
@@ -709,6 +710,7 @@ Object {
 
 exports[`public sarifReporter API converts empty/minimal axe rawObject input with no results to the pinned minimal SARIF output 1`] = `
 Object {
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": Array [
     Object {
       "artifacts": Array [

--- a/src/axe-raw-sarif-converter.ts
+++ b/src/axe-raw-sarif-converter.ts
@@ -55,6 +55,8 @@ export class AxeRawSarifConverter {
     ): Sarif.Log {
         return {
             version: '2.1.0',
+            $schema:
+                'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
             runs: [this.convertRun(results, converterOptions, environmentData)],
         };
     }

--- a/src/sarif-converter.ts
+++ b/src/sarif-converter.ts
@@ -54,6 +54,8 @@ export class SarifConverter {
     ): Sarif.Log {
         return {
             version: '2.1.0',
+            $schema:
+                'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
             runs: [this.convertRun(results, options)],
         };
     }

--- a/src/test-resources/basic-axe-v3.2.2.sarif
+++ b/src/test-resources/basic-axe-v3.2.2.sarif
@@ -1,5 +1,6 @@
 {
     "version": "2.1.0",
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
     "runs": [
       {
         "conversion": {

--- a/src/test-resources/basic-axe-v3.3.2.sarif
+++ b/src/test-resources/basic-axe-v3.3.2.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/basic-axe-v3.4.1.sarif
+++ b/src/test-resources/basic-axe-v3.4.1.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/basic-axe-v3.4.2.sarif
+++ b/src/test-resources/basic-axe-v3.4.2.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/basic-axe-v3.5.1.sarif
+++ b/src/test-resources/basic-axe-v3.5.1.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/basic-axe-v3.5.2.sarif
+++ b/src/test-resources/basic-axe-v3.5.2.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/basic-axe-v3.5.3.sarif
+++ b/src/test-resources/basic-axe-v3.5.3.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/basic-axe-v3.5.4.sarif
+++ b/src/test-resources/basic-axe-v3.5.4.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/basic-axe-v3.5.5.sarif
+++ b/src/test-resources/basic-axe-v3.5.5.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/basic-axe-v4.0.1.sarif
+++ b/src/test-resources/basic-axe-v4.0.1.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/basic-axe-v4.0.2.sarif
+++ b/src/test-resources/basic-axe-v4.0.2.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v3.2.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.2.2.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v3.3.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.3.2.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v3.4.1.sarif
+++ b/src/test-resources/w3citylights-axe-v3.4.1.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v3.4.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.4.2.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v3.5.1.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.1.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v3.5.2.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.2.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v3.5.3.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.3.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v3.5.4.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.4.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v3.5.5.sarif
+++ b/src/test-resources/w3citylights-axe-v3.5.5.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v4.0.1.sarif
+++ b/src/test-resources/w3citylights-axe-v4.0.1.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {

--- a/src/test-resources/w3citylights-axe-v4.0.2.sarif
+++ b/src/test-resources/w3citylights-axe-v4.0.2.sarif
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
       "conversion": {


### PR DESCRIPTION
#### Description of changes

Add's a $schema value to the outputted Sarif file. 
Some places, in particular GitHub [require a $schema field to be populated](https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/sarif-support-for-code-scanning#sariflog-object)

This code adds that schema url using the value from the spec. Tests have been updated to include the field.

I have validated that this change is inline with the [Sarif spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317481) 
> A sarifLog object MAY contain a property named $schema whose value is a string containing an absolute URI from which a JSON schema document [JSCHEMA01] describing the version of the SARIF format to which this log file conforms can be obtained.

Please let me know if this should be treated as a breaking change as the outputs have changed.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [x] Added relevant unit tests for your changes
- [x]  Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
