### PR TITLE
chore: add dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 version: 1
 update_configs:
     - package_manager: 'javascript'

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,32 @@
+version: 1
+update_configs:
+    - package_manager: 'javascript'
+      directory: '/'
+      update_schedule: 'daily'
+      version_requirement_updates: 'widen_ranges'
+      default_labels:
+          - 'category: engineering'
+          - 'dependencies'
+      commit_message:
+          prefix: 'chore'
+          include_scope: true
+      # axe updates require specific manual steps; see /README.md
+      ignored_updates:
+          - match:
+                dependency_name: 'axe-core'
+    - package_manager: 'javascript'
+      directory: '/src/test-resources/generator'
+      update_schedule: 'daily'
+      version_requirement_updates: 'increase_versions'
+      default_labels:
+          - 'category: engineering'
+          - 'dependencies'
+      commit_message:
+          prefix: 'chore'
+          include_scope: true
+      # axe updates require specific manual steps; see /README.md
+      ignored_updates:
+          - match:
+                dependency_name: 'axe-core'
+          - match:
+                dependency_name: '@axe-core/puppeteer'


### PR DESCRIPTION
#### Description of changes

This PR adds a config file for dependabot that enables the test-resource generator for updates and configures the tags/prefixes/etc to match what we use in other repos.

#### Pull request checklist

- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
