### PR TITLE
chore: configure semantic-release to use the main branch as our release branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,3 @@
+{
+    "branches": ["main"]
+}


### PR DESCRIPTION
#### Details

`semantic-release` understands to treat `master` as a release branch by default, but not `main` (see https://github.com/semantic-release/semantic-release/issues/1581). This PR explicitly configures semantic-release to release out of `main`.

##### Motivation

Fix our release process.

##### Context

Followup to #602

I verified locally with `yarn semantic-release --dry-run` that semantic-release does seem to be picking up the new configuration

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
