### PR TITLE
chore: try out Renovate instead of Dependabot for dependency updates

### DIFF
--- a/.github/renovate-self-host-config.json5
+++ b/.github/renovate-self-host-config.json5
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Self-hosted options (https://docs.renovatebot.com/self-hosted-configuration/)
+{
+  // Temporary during validation
+  "dryRun": true,
+  // Avoid plain "renovate", it is reserved for the GitHub App version
+  "branchPrefix": "renovate-bot",
+  "autodiscover": false,
+  "platform": "github",
+  "repositories": [
+    "microsoft/axe-sarif-converter",
+  ],
+  "onboardingConfig": {
+    "extends": ["config:base"],
+  },
+  "onboardingConfigFileName": ".github/renovate.json5",
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Repository options (https://docs.renovatebot.com/configuration-options/)
+{
+  "extends": ["config:base"],
+
+  // This delays new PRs until after standup each day to reduce standup noise.
+  // Note that this does *not* delay updates to already-open PRs.
+  // Note also that this is implicitly limited by the trigger configuration
+  // in /.github/workflows/renovate.yml.
+  "timezone": "America/Los_Angeles", // Canonical IANA name for Pacific time
+  "schedule": ["after 12pm every weekday"],
+
+  // This single line is the primary reason we're using Renovate instead of
+  // Dependabot; it offers partial mitigation for some scenarios where a
+  // transitive dependency author's npm credentials are temporarily compromised,
+  // eg, https://github.com/faisalman/ua-parser-js/issues/536
+  "stabilityDays": 7,
+
+  // Note, this limits how many new PRs can be created per hour, *not* how many
+  // PRs may be open simultaneously
+  "prHourlyLimit": 2,
+
+  "labels": ["dependencies", "category: engineering"],
+  // This must be unique to just Renovate commits; don't reuse a common bot email
+  "gitAuthor": "Renovate Bot <accessibility-insights-renovatebot@microsoft.com>",
+  "semanticCommits": "enabled", // "chore(deps):" commit prefixes
+  "baseBranches": ["main"],
+
+  "enabledManagers": ["npm", "github-actions", "azure-pipelines"],
+
+  "rangeStrategy": "bump",
+
+  "packageRules": [
+    {
+      // This matches only the root package.json, not /src/test-resources/generator/package.json
+      "matchFiles": ["package.json"],
+      "matchDepTypes": ["peerDependencies", "dependencies"],
+      "rangeStrategy": "widen",
+    },
+    {
+      "matchPackagePatterns": ["axe-core", "@axe-core/*"],
+      "dependencyDashboardApproval": true,
+    },
+  ],
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,92 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# This workflow runs a "self-hosted" Renovate configuration. We're using this
+# instead of the Renovate GitHub App because the app can only be configured
+# at the GitHub organization level, and it's unwieldy for that configuration to
+# be shared across the giant microsoft org.
+#
+# For general documentation on running Self-Hosted Renovate using their GitHub
+# action like this, see:
+#
+#   * https://github.com/renovatebot/github-action
+#   * https://docs.renovatebot.com/self-hosted-configuration
+#
+# This workflow is currently an experiment to test Renovate on a small scale.
+# If we like how it works in this repo, we would probably want to create an
+# independent repo like microsoft/accessibility-insights-renovate-config to
+# contain this workflow + the self-host config + a shared Renovate preset,
+# and have the workflow run once against all our repos rather than repeating
+# the config and CI cost for each repo.
+
+name: Renovate
+
+# Note that the triggers for this workflow only control how often renovate
+# should check to see if there are updates to perform. Certain updates (eg,
+# rebasing open PRs when yarn.lock is updated in main) will happen immediately
+# on the next update check, but new PRs will only be opened according to the
+# schedule property of /.github/renovate.json5
+#
+# Note that this requires a GitHub PAT (secrets.RENOVATE_TOKEN) which has more
+# privileges than is safe to use with PRs from forks. *Do not* add triggers
+# against pull_request (or to "push" with non-protected branches).
+on:
+  push:
+    branches: ['main']
+    paths:
+      - '**/package.json'
+      - '**/yarn.lock'
+  schedule:
+    # This reads "every 15 minutes on weekdays from 7am-7pm PST (3pm-3am UTC),
+    # and hourly outside of that".
+    - cron: '15,30,45 15,16,17,18,19,20,21,22,23,0,1,2,3 * * MON-FRI'
+    - cron: '0 * * * *'
+  # Other repositories can trigger an immediate Renovate update by dispatching a
+  # repository event of type "trigger_renovate" to this repository. To do so,
+  # you'd want to create a workflow that runs the following (probably triggered
+  # on pushes of package.json/yarn.lock/etc files to main) using a PAT with
+  # "repo:public" access to this repository:
+  #
+  # run: |
+  #   curl -XPOST -u "${{secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/microsoft/accessibility-insights-renovate/dispatches --data '{"event_type": "trigger_renovate"}'
+  #
+  # Such a PAT is a sensitive secret, so you'd want to set this up in its own
+  # isolated workflow and make sure it never runs from a fork or untrusted
+  # package update branch.
+  repository_dispatch:
+    types: ['trigger_renovate']
+
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
+
+        # Turnstyle blocks the workflow until all other instances of the same
+        # workflow have completed. This prevents renovate from competing with
+        # other instances of itself if a repository_dispatch trigger occurs
+        # simultaneously with a scheduled trigger.
+      - name: Turnstyle
+        uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65 # renovate: tag=v0.1.5
+        with:
+          abort-after-seconds: 180
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Renovate
+        uses: renovate/github-action@91ff5cef6fb318217014678dd09ccb81f3ace5a8 # renovate: tag=v29.17.0
+        with:
+          configurationFile: /.github/renovate-self-host-config.json5
+          # This should be a PAT from our build bot account with these scopes:
+          #
+          #   * repo:public_repo (allows Renovate to create/update PRs in public
+          #     repos)
+          #   * workflow (allows Renovate to propose version updates in
+          #     otherwise-protected /.github/workflows/* files)
+          #   * repo (allows Renovate to create/update PRs in private repos)
+          #
+          # See https://github.com/renovatebot/github-action#token
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        # If you need to debug this action, start by uncommenting this line:
+        # env: { LOG_LEVEL: 'debug' }


### PR DESCRIPTION
#### Details

This PR is an initial attempt to trial using [Renovate](https://docs.renovatebot.com/) instead of Dependabot for automated dependency updates.

This PR uses renovate/github-action to implement a self-hosted Renovate configuration. At a high level, this works by using a GitHub workflow that runs on a schedule every 15 minutes to run a "renovate" command, which queries for any new dependency updates and creates/updates/merges any required dependency update PRs.

For the purposes of the trial experiment, this workflow is currently set up just in this local repo. If we like how this works in `axe-sarif-converter`, I think the better long-term solution would be to create a separate `microsoft/accessibility-insights-renovate-config` repo to contain a single common worker workflow + config preset, and to have one worker covering updates for all of our repos rather than repeating this workflow/config/etc in each of our repos.

This initial PR sets `"dryRun": true` in `renovate-self-host-config.json5`; once this is merged and I've checked over the dry run log file, a separate PR will remove that config line to enable the workflow to actually update PRs.

##### Motivation

The primary motivations for trying this are:

* Renovate's `stabilityDays` config option would act as partial mitigation for issues like the ua-parser-js compromise we saw a few weeks ago (it doesn't solve issues where a package's maintainer is malicious, but it mitigates issues where a non-malicious maintainer's publishing credentials are temporarily compromised)
* Renovate supports more package managers than Dependabot does. Notably, it supports both pnpm and yarn v3; these are appealing because they both have a better version of the yarn v1 `resolutions` we currently use for certain security updates in transitive dependencies, which currently forces us to accept technical debt every time we have to use them.
* Renovate supports grouping related package updates together. Its default `config:base` preset includes grouping for many common monorepos (eg, gatsby, jest, babel), and it also supports user-defined groupings.
* Renovate supports granular automerge settings (eg, "automerge any @types/* packages with passing tests, but don't automerge any other packages")

##### Context

There are two major alternatives to the self-hosted GitHub Action configuration:

* The Renovate GitHub App: I dismissed this because it requires configuration at the level of the `microsoft` GitHub organization, which we didn't want to treat as a blocker for trial experiment purposes
* Self-hosting via an Azure VM running a cron job: I dismissed this because it seemed like it would require both slightly more cost and slightly more dev overhead (in terms of managing OS updates/etc) than the GitHub Actions version. That said, if performance turns out to be an issue, this would be a reasonable alternative.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
