### PR TITLE
chore: incremental fixes to experimental Renovate workflow (part 2)

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Renovate
         uses: renovatebot/github-action@91ff5cef6fb318217014678dd09ccb81f3ace5a8 # renovate: tag=v29.17.0
         with:
-          configurationFile: /.github/renovate-self-host-config.json5
+          configurationFile: .github/renovate-self-host-config.json5
           # This should be a PAT from our build bot account with these scopes:
           #
           #   * repo:public_repo (allows Renovate to create/update PRs in public


### PR DESCRIPTION
#### Details

* Fixes the path to the self-host-config file to be relative to the repo root, rather than assuming it's under `/`

##### Motivation

See #685

##### Context

See #685

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
