### PR TITLE
chore(deps): re-enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+
 updates:
 - package-ecosystem: npm
   directory: "/"


### PR DESCRIPTION
#### Details

This PR makes a no-op change to dependabot.yml to force Dependabot to re-evaluate the config file.

This is an attempt to work around an issue where, currently, Dependabot isn't processing non-security updates for this repo. The proximate cause is visible under the `Insights > Dependency Graph > Dependabot` GitHub UI for this repo, which shows this error:

```
The property '#/updates/1/ignore/0/versions' includes a duplicate. Ignores must have a unique combination of 'dependency-name' and 'versions'
The property '#/updates/1/ignore/2/versions' includes a duplicate. Ignores must have a unique combination of 'dependency-name' and 'versions'
```

I think this is a bogus error (the "duplicates" are in a different `updates` item, not the same item), so I'm starting by trying to see if Dependabot has fixed their parser to allow this case; if that doesn't work, I'll try updating the `versions` specifiers to be logically equivalent but not lexically equivalent (and file a Dependabot bug).

##### Motivation

Re-enable dependabot updates in the repo

##### Context

https://github.com/dependabot/dependabot-core/issues/2574#issuecomment-775843091

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [ ] (if applicable) Addresses issue: #0000
- [ ] Added relevant unit tests for your changes
- [ ] Ran `yarn precheckin`
- [ ] Verified code coverage for the changes made
