### PR TITLE
chore(deps-dev): bump version of node used for CI to 14.18.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,8 @@ jobs:
           # can require of our users without a breaking change
           - task: NodeTool@0
             inputs:
-                versionSpec: '14.15.0'
-            displayName: use node 14.15.0
+                versionSpec: '14.18.3'
+            displayName: use node 14.18.3
 
           - script: yarn install --frozen-lockfile
             displayName: yarn install


### PR DESCRIPTION
#### Details

`semantic-release@18.0.0` includes a breaking change that requires node >= 14.17.0. This bumps our CI environment to the latest v14 node version to unblock #697 

##### Motivation

Unblocks other dep updates

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
