### PR TITLE
chore: Adding required SECURITY.md file to the repo

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,4 @@ test-resources/
 LICENSE
 yarn.lock
 copyright-header.txt
+SECURITY.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.6 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/msrc/pgp-key-msrc).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://microsoft.com/msrc/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/msrc/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,8 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+
 <!-- BEGIN MICROSOFT SECURITY.MD V0.0.6 BLOCK -->
 
 ## Security


### PR DESCRIPTION
We are adding the latest version of the SECURITY.md file as found here: https://github.com/microsoft/repo-templates/blob/main/shared/SECURITY.md.

#### Details

<!-- Usually a sentence or two describing what the PR changes -->
After checking with the Github in Microsoft (GiM) team, we are being asked to add this file to all of our open-source repos. This file is used to help the community understand the Microsoft open source security policy and how to safely report security issues. GitHub uses the presence of this file to light-up security reminders and a link to the file. More information for internal reference can be found here: https://aka.ms/opensource

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->
Ensures compliance with GiM/Open Source policy preferences

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [x] (if applicable) Addresses issue: #0000
- [x] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [x] Verified code coverage for the changes made
