### PR TITLE
chore: add combine-dependabot-prs workflow

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: "Combine Dependabot PRs"
+on:
+  schedule:
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+
+jobs:
+  combine-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+      - uses: maadhattah/combine-dependabot-prs@e4dc7e045b018ee1e963a1a67bccbbf8ff3b176f
+        with:
+          branchPrefix: "dependabot"
+          mustBeGreen: true
+          combineBranchName: combined-prs-${{ github.run_id }}
+          ignoreLabel: "pr: do not combine"
+          baseBranch: "main"
+          openPR: true


### PR DESCRIPTION
#### Details

Add a new workflow to automatically combine dependabot PRs into a single PR. Any PR with a failing build or the `pr: do not combine` label will be excluded from the new combined PR.

This workflow runs automatically every Monday at 1PM UTC (6AM PST), or it can be run manually from the "actions" tab in the repo.

##### Motivation

Reduce the number of dependabot commits in the repo

##### Context

This action is already used in the [accessibility-insights-service](https://github.com/microsoft/accessibility-insights-service) repo on a manual trigger. After a discussion, our team has decided to experiment with using this action on an automatic trigger in our other repos.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [n/a] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
