### PR TITLE
chore: Enable write permissions for combine-dependabot-prs

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 13 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   combine-prs:
     if: github.event_name != 'schedule' || github.repository_owner == 'microsoft'


### PR DESCRIPTION
#### Details

Enable write permissions for combine-dependabot-prs

##### Motivation

The repo is configured to only allow read permissions to workflows. The combined-dependabot-prs action requires write permissions to create PRs

##### Context

Tested in [accessibility-insights-web](https://github.com/microsoft/accessibility-insights-web/actions/runs/3499742576)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [n/a] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
