### PR TITLE
chore: Use newer Ubuntu LTS version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ jobs:
     - job: 'tests_and_checks'
 
       pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-22.04'
 
       steps:
           # This is later than the minimum version the package claims support


### PR DESCRIPTION
#### Details

As described at https://github.com/actions/virtual-environments/issues/6002, Ubuntu 18.04 is being phased out. This moves to Ubuntu 22.04, which is the current LTS version.

##### Motivation

Use current versions

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [x] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue:
- [n/a] Added relevant unit tests for your changes
- [x] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
