### PR TITLE
fix: repair local build break after rimraf v4 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "scripts": {
         "prebuild": "yarn clean",
         "build": "tsc -p .",
-        "clean": "rimraf dist/* test-results/*",
+        "clean": "rimraf dist test-results",
         "test": "jest",
         "lint": "eslint src/**/*.{js,ts,tsx}",
         "format": "prettier --config prettier.config.js --write \"**/*\"",


### PR DESCRIPTION
#### Details

PR #897 updated `rimraf` from 3.0.2 to 4.0.4. Unfortunately, rimraf v4 [dropped support for globs](https://github.com/isaacs/rimraf#major-changes-from-v3-to-v4) which we were using in `yarn clean` to delete the `dist` and `test-results` folders, so that started erroring out. Since `yarn clean` is called by `yarn prebuild`, this broke running local builds. PR and CI builds were not affected. This change removes the use of globs.

##### Motivation

Get local builds working again.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [X] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [X] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [X] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
