### PR TITLE
chore: enable CodeQL analysis in CI builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+variables:
+    Codeql.Enabled: true
+
 jobs:
     - job: 'tests_and_checks'
 


### PR DESCRIPTION
#### Details

CodeQL support is automatically injected into our CI builds but requires a variable to be set to enable analysis.

##### Motivation

Security requirement.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [X] PR title respects [Conventional Commits](https://www.conventionalcommits.org) (starts with `fix:`, `feat:`, etc, and is suitable for user-facing release notes)
- [X] PR contains no breaking changes, **OR** description of both PR **and final merge commit** starts with `BREAKING CHANGE:`
- [n/a] (if applicable) Addresses issue: #0000
- [n/a] Added relevant unit tests for your changes
- [X] Ran `yarn precheckin`
- [n/a] Verified code coverage for the changes made
